### PR TITLE
Add high-level wrappers for accumulate ecallis (14-21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,20 @@ sdk/                        AssemblyScript SDK library
     refine/                 Ecalli 6-13 (historical_lookup, export, machine, peek, poke, pages, invoke, expunge)
     accumulate/             Ecalli 14-26 (bless, assign, designate, checkpoint, new_service, upgrade, transfer, eject, query, solicit, forget, yield_result, provide)
   jam/                      JAM protocol types
-    types.ts                Core type aliases (ServiceId, Slot, CodeHash, etc.)
+    types.ts                Core type aliases (ServiceId, Slot, CodeHash, etc.) + ValidatorKey, AutoAccumulateEntry
     service.ts              Service ABI: RefineArgs, AccumulateArgs, Response + codec classes
     account-info.ts         AccountInfo (96-byte service info from ecalli 5) + AccountInfoCodec
     service-data.ts         ServiceData (info, read) + CurrentServiceData (adds write) — high-level storage wrappers
     fetcher.ts              Base Fetcher class with buffer management (constants only)
     work-package-fetcher.ts Intermediate fetcher adding typed kinds 7-13 (WorkPackage, etc.)
     work-package.ts         WorkPackage, WorkItem, WorkItemInfo, RefinementContext, ImportRef, ExtrinsicRef + codec classes
-    accumulate/             Accumulate-context types and fetcher
+    accumulate/             Accumulate-context types, fetcher, and high-level wrappers
       item.ts               Operand, PendingTransfer, WorkExecResult, AccumulateItem + codec classes
       fetcher.ts            AccumulateFetcher (entropy, allTransfersAndOperands, oneTransferOrOperand)
+      admin.ts              Admin (bless, blessDelegator, blessRegistrar, assign, designate) — privileged governance
+      child-services.ts     ChildServices (newChild, ejectChild) — child service lifecycle
+      self-service.ts       SelfService (upgradeCode, requestEjection) — self-management
+      memo.ts               Memo — fixed 128-byte transfer memo with auto-pad/truncate
     refine/                 Refine-context fetcher and machine wrapper
       fetcher.ts            RefineFetcher (entropy, authorizerTrace, extrinsics, imports + inherits kinds 7-13)
       machine.ts            Machine (inner PVM lifecycle: create, peek, poke, pages, invoke, expunge)
@@ -117,7 +121,7 @@ export function accumulate(ptr: u32, len: u32): u64 {
 ```
 
 Contexts:
-- **AccumulateContext** — `parseArgs()` (panics on invalid data), `respond()`, `yieldHash()`, `checkpoint()`, `yieldResult()`, accumulate codecs
+- **AccumulateContext** — `parseArgs()` (panics on invalid data), `respond()`, `yieldHash()`, `checkpoint()`, `yieldResult()`, `scheduleTransfer()`, accumulate codecs
 - **RefineContext** (extends WorkPackageContext) — `parseArgs()` (panics on invalid data), `respond()`, `exportSegment()`, refine + work-package codecs
 - **AuthorizeContext** — `parseCoreIndex(ptr, len)` returns `CoreIndex` (u16). No codec state.
 - **WorkPackageContext** — base with bytes32, protocolConstants, workPackage, etc.

--- a/docs/src/sdk-api/accumulate.md
+++ b/docs/src/sdk-api/accumulate.md
@@ -16,6 +16,14 @@ export function accumulate(ptr: u32, len: u32): u64 {
 
   const gas = ctx.checkpoint();          // i64 — commit state, return remaining gas
   ctx.yieldResult(Bytes32.zero());       // provide accumulation result hash
+
+  // Schedule a transfer (executes after accumulation completes)
+  const r1 = ctx.scheduleTransfer(42, 1000, 100);  // ResultN<bool, TransferError>
+
+  // Transfer with explicit memo
+  const memo = Memo.create(BytesBlob.encodeAscii("hello"));
+  const r2 = ctx.scheduleTransfer(42, 1000, 100, memo);
+
   return ctx.yieldHash(null);
 }
 ```
@@ -74,3 +82,77 @@ up to 3 timeslot fields:
 | `Available` | `slot0` | Currently available (added at slot0) |
 | `Unavailable` | `slot0`, `slot1` | Was available, now removed |
 | `Reavailable` | `slot0`, `slot1`, `slot2` | Removed then re-added |
+
+## Admin (Privileged Governance)
+
+High-level wrappers for ecallis 14-16 (`bless`, `assign`, `designate`). Only
+callable by privileged services (manager, delegator, registrar, core assigners).
+
+```typescript
+import {
+  Admin, AutoAccumulateEntry, ValidatorKey,
+  Bytes32, BytesBlob,
+} from "@fluffylabs/as-lan";
+
+const admin = Admin.create();
+
+// Full bless — only the manager can set all fields
+admin.bless(
+  managerServiceId,
+  [assigner1, assigner2],       // one ServiceId per core
+  delegatorServiceId,
+  registrarServiceId,
+  [AutoAccumulateEntry.create(100, 5000)],
+);  // ResultN<bool, BlessError>
+
+// Partial bless — delegator/registrar can transfer their own role
+admin.blessDelegator(newDelegatorId);   // ResultN<bool, BlessError>
+admin.blessRegistrar(newRegistrarId);   // ResultN<bool, BlessError>
+
+// Assign auth queue for a core (only that core's assigner)
+admin.assign(coreIndex, [codeHash1, codeHash2]);  // ResultN<bool, AssignError>
+
+// Transfer assigner permission to another service
+admin.assign(coreIndex, authQueue, newAssignerServiceId);
+
+// Designate next epoch validators
+const key = ValidatorKey.create(ed25519, bandersnatch, bls, metadata);
+admin.designate([key]);  // ResultN<bool, DesignateError>
+```
+
+## Child Services
+
+Create and eject child services (ecallis 18, 21).
+
+```typescript
+import { ChildServices, Bytes32 } from "@fluffylabs/as-lan";
+
+const cs = ChildServices.create();
+
+// Create a child service
+const result = cs.newChild(codeHash, codeLen, gas, allowance);
+// ResultN<ServiceId, NewChildError>
+if (result.isOkay) {
+  const childId = result.okay;  // the new ServiceId
+}
+
+// Eject a child service (it must have called requestEjection first)
+cs.ejectChild(childServiceId, prevCodeHash);  // ResultN<bool, EjectChildError>
+```
+
+## Self-Service
+
+Upgrade the current service's code or request ejection (ecalli 19).
+
+```typescript
+import { SelfService, Bytes32 } from "@fluffylabs/as-lan";
+
+const self = SelfService.create();
+
+// Upgrade to new code (ensure preimage is available first!)
+self.upgradeCode(newCodeHash, minGas, allowance);
+
+// Request ejection by a parent service
+// WARNING: clear all storage before calling this!
+self.requestEjection(parentServiceId);
+```

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -232,6 +232,45 @@ TestStorage.set(key, value);
 TestStorage.set(key, null);
 ```
 
+### TestPrivileged
+
+Configure the return values of privileged governance ecallis (bless, assign, designate):
+
+```typescript
+import { TestPrivileged } from "@fluffylabs/as-lan/test";
+import { EcalliResult } from "@fluffylabs/as-lan";
+
+TestPrivileged.setBlessResult(EcalliResult.WHO);
+TestPrivileged.setAssignResult(EcalliResult.CORE);
+TestPrivileged.setDesignateResult(EcalliResult.HUH);
+```
+
+### TestServices
+
+Configure the return values of service lifecycle ecallis (new_service, eject):
+
+```typescript
+import { TestServices } from "@fluffylabs/as-lan/test";
+import { EcalliResult } from "@fluffylabs/as-lan";
+
+TestServices.setNewServiceResult(EcalliResult.CASH);
+TestServices.setEjectResult(EcalliResult.WHO);
+```
+
+By default, `new_service()` returns auto-incrementing service IDs (256, 257, ...).
+Setting a result overrides this behavior until reset.
+
+### TestTransfer
+
+Configure the return value of the `transfer()` ecalli:
+
+```typescript
+import { TestTransfer } from "@fluffylabs/as-lan/test";
+import { EcalliResult } from "@fluffylabs/as-lan";
+
+TestTransfer.setTransferResult(EcalliResult.CASH);
+```
+
 ### TestEcalli
 
 Reset all configuration to defaults and clear storage:

--- a/sdk-ecalli-mocks/src/accumulate/index.ts
+++ b/sdk-ecalli-mocks/src/accumulate/index.ts
@@ -1,18 +1,28 @@
 // Accumulate ecalli mock stubs (14-26).
 
-export { bless, assign, designate } from "./privileged.js";
+export {
+  bless, assign, designate,
+  setBlessResult, setAssignResult, setDesignateResult, resetPrivileged,
+} from "./privileged.js";
 export { checkpoint } from "./checkpoint.js";
-export { new_service, upgrade, eject, resetServices } from "./services.js";
-export { transfer } from "./transfer.js";
+export {
+  new_service, upgrade, eject,
+  setNewServiceResult, setEjectResult, resetServices,
+} from "./services.js";
+export { transfer, setTransferResult, resetTransfer } from "./transfer.js";
 export {
   query, solicit, forget, yield_result, provide,
   setQueryResult, setSolicitResult, setForgetResult, setProvideResult, resetPreimages,
 } from "./preimages.js";
 
+import { resetPrivileged } from "./privileged.js";
 import { resetServices } from "./services.js";
+import { resetTransfer } from "./transfer.js";
 import { resetPreimages } from "./preimages.js";
 
 export function resetAccumulate(): void {
+  resetPrivileged();
   resetServices();
+  resetTransfer();
   resetPreimages();
 }

--- a/sdk-ecalli-mocks/src/accumulate/index.ts
+++ b/sdk-ecalli-mocks/src/accumulate/index.ts
@@ -7,7 +7,9 @@ export {
 export { checkpoint } from "./checkpoint.js";
 export {
   new_service, upgrade, eject,
-  setNewServiceResult, setEjectResult, resetServices,
+  setNewServiceResult, setEjectResult,
+  getLastUpgradeCodeHashPtr, getLastUpgradeGas, getLastUpgradeAllowance,
+  resetServices,
 } from "./services.js";
 export { transfer, setTransferResult, resetTransfer } from "./transfer.js";
 export {

--- a/sdk-ecalli-mocks/src/accumulate/index.ts
+++ b/sdk-ecalli-mocks/src/accumulate/index.ts
@@ -5,6 +5,8 @@ export {
   setBlessResult, setAssignResult, setDesignateResult,
   getLastBlessManager, getLastBlessAssignersPtr, getLastBlessDelegator,
   getLastBlessRegistrar, getLastBlessAutoAccumPtr, getLastBlessAutoAccumCount,
+  getLastAssignCore, getLastAssignAuthQueuePtr, getLastAssignNewAssigner,
+  getLastDesignateValidatorsPtr,
   resetPrivileged,
 } from "./privileged.js";
 export { checkpoint } from "./checkpoint.js";

--- a/sdk-ecalli-mocks/src/accumulate/index.ts
+++ b/sdk-ecalli-mocks/src/accumulate/index.ts
@@ -2,7 +2,10 @@
 
 export {
   bless, assign, designate,
-  setBlessResult, setAssignResult, setDesignateResult, resetPrivileged,
+  setBlessResult, setAssignResult, setDesignateResult,
+  getLastBlessManager, getLastBlessAssignersPtr, getLastBlessDelegator,
+  getLastBlessRegistrar, getLastBlessAutoAccumPtr, getLastBlessAutoAccumCount,
+  resetPrivileged,
 } from "./privileged.js";
 export { checkpoint } from "./checkpoint.js";
 export {

--- a/sdk-ecalli-mocks/src/accumulate/privileged.ts
+++ b/sdk-ecalli-mocks/src/accumulate/privileged.ts
@@ -40,21 +40,39 @@ export function getLastBlessRegistrar(): number { return lastBlessRegistrar; }
 export function getLastBlessAutoAccumPtr(): number { return lastBlessAutoAccumPtr; }
 export function getLastBlessAutoAccumCount(): number { return lastBlessAutoAccumCount; }
 
-/** Ecalli 15: Assign core auth queue. */
+// Assign call capture
+let lastAssignCore = 0;
+let lastAssignAuthQueuePtr = 0;
+let lastAssignNewAssigner = 0;
+
+/** Ecalli 15: Assign core auth queue. Captures args. */
 export function assign(
   _core: number,
   _auth_queue_ptr: number,
   _new_assigner: number,
 ): bigint {
+  lastAssignCore = _core;
+  lastAssignAuthQueuePtr = _auth_queue_ptr;
+  lastAssignNewAssigner = _new_assigner;
   return assignResult;
 }
 
-/** Ecalli 16: Designate next epoch validators. */
+export function getLastAssignCore(): number { return lastAssignCore; }
+export function getLastAssignAuthQueuePtr(): number { return lastAssignAuthQueuePtr; }
+export function getLastAssignNewAssigner(): number { return lastAssignNewAssigner; }
+
+// Designate call capture
+let lastDesignateValidatorsPtr = 0;
+
+/** Ecalli 16: Designate next epoch validators. Captures args. */
 export function designate(
   _validators_ptr: number,
 ): bigint {
+  lastDesignateValidatorsPtr = _validators_ptr;
   return designateResult;
 }
+
+export function getLastDesignateValidatorsPtr(): number { return lastDesignateValidatorsPtr; }
 
 export function setBlessResult(result: bigint): void {
   blessResult = result;
@@ -78,4 +96,8 @@ export function resetPrivileged(): void {
   lastBlessRegistrar = 0;
   lastBlessAutoAccumPtr = 0;
   lastBlessAutoAccumCount = 0;
+  lastAssignCore = 0;
+  lastAssignAuthQueuePtr = 0;
+  lastAssignNewAssigner = 0;
+  lastDesignateValidatorsPtr = 0;
 }

--- a/sdk-ecalli-mocks/src/accumulate/privileged.ts
+++ b/sdk-ecalli-mocks/src/accumulate/privileged.ts
@@ -1,32 +1,54 @@
 // Ecalli 14-16: Privileged governance operations.
 //
 // bless (14), assign (15), designate (16) — only callable by the
-// privileged service (manager). All return OK in test stubs.
+// privileged service (manager/delegator/registrar). Configurable results.
 
-/** Ecalli 14: Bless — set privileged service configuration. Returns OK. */
+let blessResult = 0n;
+let assignResult = 0n;
+let designateResult = 0n;
+
+/** Ecalli 14: Bless — set privileged service configuration. */
 export function bless(
   _manager: number,
-  _auth_queue_ptr: number,
+  _assigners_ptr: number,
   _delegator: number,
   _registrar: number,
   _auto_accum_ptr: number,
   _auto_accum_count: number,
 ): bigint {
-  return 0n; // OK
+  return blessResult;
 }
 
-/** Ecalli 15: Assign core — returns OK. */
+/** Ecalli 15: Assign core auth queue. */
 export function assign(
   _core: number,
   _auth_queue_ptr: number,
-  _assigners: number,
+  _new_assigner: number,
 ): bigint {
-  return 0n; // OK
+  return assignResult;
 }
 
-/** Ecalli 16: Designate next epoch validators — returns OK. */
+/** Ecalli 16: Designate next epoch validators. */
 export function designate(
   _validators_ptr: number,
 ): bigint {
-  return 0n; // OK
+  return designateResult;
+}
+
+export function setBlessResult(result: bigint): void {
+  blessResult = result;
+}
+
+export function setAssignResult(result: bigint): void {
+  assignResult = result;
+}
+
+export function setDesignateResult(result: bigint): void {
+  designateResult = result;
+}
+
+export function resetPrivileged(): void {
+  blessResult = 0n;
+  assignResult = 0n;
+  designateResult = 0n;
 }

--- a/sdk-ecalli-mocks/src/accumulate/privileged.ts
+++ b/sdk-ecalli-mocks/src/accumulate/privileged.ts
@@ -7,7 +7,15 @@ let blessResult = 0n;
 let assignResult = 0n;
 let designateResult = 0n;
 
-/** Ecalli 14: Bless — set privileged service configuration. */
+// Bless call capture
+let lastBlessManager = 0;
+let lastBlessAssignersPtr = 0;
+let lastBlessDelegator = 0;
+let lastBlessRegistrar = 0;
+let lastBlessAutoAccumPtr = 0;
+let lastBlessAutoAccumCount = 0;
+
+/** Ecalli 14: Bless — set privileged service configuration. Captures args. */
 export function bless(
   _manager: number,
   _assigners_ptr: number,
@@ -16,8 +24,21 @@ export function bless(
   _auto_accum_ptr: number,
   _auto_accum_count: number,
 ): bigint {
+  lastBlessManager = _manager;
+  lastBlessAssignersPtr = _assigners_ptr;
+  lastBlessDelegator = _delegator;
+  lastBlessRegistrar = _registrar;
+  lastBlessAutoAccumPtr = _auto_accum_ptr;
+  lastBlessAutoAccumCount = _auto_accum_count;
   return blessResult;
 }
+
+export function getLastBlessManager(): number { return lastBlessManager; }
+export function getLastBlessAssignersPtr(): number { return lastBlessAssignersPtr; }
+export function getLastBlessDelegator(): number { return lastBlessDelegator; }
+export function getLastBlessRegistrar(): number { return lastBlessRegistrar; }
+export function getLastBlessAutoAccumPtr(): number { return lastBlessAutoAccumPtr; }
+export function getLastBlessAutoAccumCount(): number { return lastBlessAutoAccumCount; }
 
 /** Ecalli 15: Assign core auth queue. */
 export function assign(
@@ -51,4 +72,10 @@ export function resetPrivileged(): void {
   blessResult = 0n;
   assignResult = 0n;
   designateResult = 0n;
+  lastBlessManager = 0;
+  lastBlessAssignersPtr = 0;
+  lastBlessDelegator = 0;
+  lastBlessRegistrar = 0;
+  lastBlessAutoAccumPtr = 0;
+  lastBlessAutoAccumCount = 0;
 }

--- a/sdk-ecalli-mocks/src/accumulate/services.ts
+++ b/sdk-ecalli-mocks/src/accumulate/services.ts
@@ -21,13 +21,32 @@ export function new_service(
   return BigInt(serviceCounter++);
 }
 
-/** Ecalli 19: Upgrade service code — returns OK. */
+let lastUpgradeCodeHashPtr = -1;
+let lastUpgradeGas = 0n;
+let lastUpgradeAllowance = 0n;
+
+/** Ecalli 19: Upgrade service code — returns OK. Captures args for test assertions. */
 export function upgrade(
   _code_hash_ptr: number,
   _gas: bigint,
   _allowance: bigint,
 ): bigint {
+  lastUpgradeCodeHashPtr = _code_hash_ptr;
+  lastUpgradeGas = _gas;
+  lastUpgradeAllowance = _allowance;
   return 0n; // OK
+}
+
+export function getLastUpgradeCodeHashPtr(): number {
+  return lastUpgradeCodeHashPtr;
+}
+
+export function getLastUpgradeGas(): bigint {
+  return lastUpgradeGas;
+}
+
+export function getLastUpgradeAllowance(): bigint {
+  return lastUpgradeAllowance;
 }
 
 /** Ecalli 21: Eject service — returns OK or error sentinel. */
@@ -50,4 +69,7 @@ export function resetServices(): void {
   serviceCounter = DEFAULT_SERVICE_START;
   newServiceResultOverride = null;
   ejectResult = 0n;
+  lastUpgradeCodeHashPtr = -1;
+  lastUpgradeGas = 0n;
+  lastUpgradeAllowance = 0n;
 }

--- a/sdk-ecalli-mocks/src/accumulate/services.ts
+++ b/sdk-ecalli-mocks/src/accumulate/services.ts
@@ -1,12 +1,14 @@
 // Ecalli 18-19, 21: Service lifecycle operations.
 //
 // new_service (18), upgrade (19), eject (21) — create, upgrade, or
-// remove services.
+// remove services. Configurable results.
 
 const DEFAULT_SERVICE_START = 256;
 let serviceCounter = DEFAULT_SERVICE_START;
+let newServiceResultOverride: bigint | null = null;
+let ejectResult = 0n;
 
-/** Ecalli 18: Create new service — returns incrementing service ID. */
+/** Ecalli 18: Create new service — returns service ID or error sentinel. */
 export function new_service(
   _code_hash_ptr: number,
   _code_len: number,
@@ -15,6 +17,7 @@ export function new_service(
   _gratis_storage: number,
   _requested_id: number,
 ): bigint {
+  if (newServiceResultOverride !== null) return newServiceResultOverride;
   return BigInt(serviceCounter++);
 }
 
@@ -27,14 +30,24 @@ export function upgrade(
   return 0n; // OK
 }
 
-/** Ecalli 21: Eject service — returns OK. */
+/** Ecalli 21: Eject service — returns OK or error sentinel. */
 export function eject(
   _service: number,
   _prev_code_hash_ptr: number,
 ): bigint {
-  return 0n; // OK
+  return ejectResult;
+}
+
+export function setNewServiceResult(result: bigint): void {
+  newServiceResultOverride = result;
+}
+
+export function setEjectResult(result: bigint): void {
+  ejectResult = result;
 }
 
 export function resetServices(): void {
   serviceCounter = DEFAULT_SERVICE_START;
+  newServiceResultOverride = null;
+  ejectResult = 0n;
 }

--- a/sdk-ecalli-mocks/src/accumulate/transfer.ts
+++ b/sdk-ecalli-mocks/src/accumulate/transfer.ts
@@ -1,11 +1,21 @@
-// Ecalli 20: Transfer funds.
+// Ecalli 20: Transfer funds. Configurable result.
 
-/** Ecalli 20: Transfer balance to another service — returns OK. */
+let transferResult = 0n;
+
+/** Ecalli 20: Transfer balance to another service. */
 export function transfer(
   _dest: number,
   _amount: bigint,
   _gas_fee: bigint,
   _memo_ptr: number,
 ): bigint {
-  return 0n; // OK
+  return transferResult;
+}
+
+export function setTransferResult(result: bigint): void {
+  transferResult = result;
+}
+
+export function resetTransfer(): void {
+  transferResult = 0n;
 }

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -40,6 +40,7 @@ export { checkpoint } from "./accumulate/index.js";
 export {
   new_service, upgrade, eject,
   setNewServiceResult, setEjectResult,
+  getLastUpgradeCodeHashPtr, getLastUpgradeGas, getLastUpgradeAllowance,
 } from "./accumulate/index.js";
 export { transfer, setTransferResult } from "./accumulate/index.js";
 export {

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -32,10 +32,16 @@ export {
 } from "./refine/index.js";
 
 // Accumulate ecalli stubs (14-26)
-export { bless, assign, designate } from "./accumulate/index.js";
+export {
+  bless, assign, designate,
+  setBlessResult, setAssignResult, setDesignateResult,
+} from "./accumulate/index.js";
 export { checkpoint } from "./accumulate/index.js";
-export { new_service, upgrade, eject } from "./accumulate/index.js";
-export { transfer } from "./accumulate/index.js";
+export {
+  new_service, upgrade, eject,
+  setNewServiceResult, setEjectResult,
+} from "./accumulate/index.js";
+export { transfer, setTransferResult } from "./accumulate/index.js";
 export {
   query, solicit, forget, yield_result, provide,
   setQueryResult, setSolicitResult, setForgetResult, setProvideResult,

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -35,6 +35,8 @@ export {
 export {
   bless, assign, designate,
   setBlessResult, setAssignResult, setDesignateResult,
+  getLastBlessManager, getLastBlessAssignersPtr, getLastBlessDelegator,
+  getLastBlessRegistrar, getLastBlessAutoAccumPtr, getLastBlessAutoAccumCount,
 } from "./accumulate/index.js";
 export { checkpoint } from "./accumulate/index.js";
 export {

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -37,6 +37,8 @@ export {
   setBlessResult, setAssignResult, setDesignateResult,
   getLastBlessManager, getLastBlessAssignersPtr, getLastBlessDelegator,
   getLastBlessRegistrar, getLastBlessAutoAccumPtr, getLastBlessAutoAccumCount,
+  getLastAssignCore, getLastAssignAuthQueuePtr, getLastAssignNewAssigner,
+  getLastDesignateValidatorsPtr,
 } from "./accumulate/index.js";
 export { checkpoint } from "./accumulate/index.js";
 export {

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -46,7 +46,7 @@ export {
   setNewServiceResult, setEjectResult,
   getLastUpgradeCodeHashPtr, getLastUpgradeGas, getLastUpgradeAllowance,
 } from "./accumulate/index.js";
-export { transfer, setTransferResult } from "./accumulate/index.js";
+export { transfer, setTransferResult, resetTransfer } from "./accumulate/index.js";
 export {
   query, solicit, forget, yield_result, provide,
   setQueryResult, setSolicitResult, setForgetResult, setProvideResult,

--- a/sdk/ecalli/accumulate/assign.ts
+++ b/sdk/ecalli/accumulate/assign.ts
@@ -1,19 +1,21 @@
 /**
  * Ecalli 15: Assign core.
  *
- * Assign a core to authorization work.
+ * Assign an auth queue for a specific core. Only callable by that core's
+ * assigner service (set via bless). The new_assigner parameter allows
+ * transferring the assigner permission to another service.
  *
  * Registers:
  * - r7 (in)  = c — core index
  * - r7 (out)     — OK, CORE, HUH, or WHO
  * - r8 (in)  = a — auth queue memory address
- * - r9 (in)  = s — assigners (bitmask)
+ * - r9 (in)  = s — new assigner service ID
  *
  * @param core - core index
  * @param auth_queue_ptr - auth queue memory address
- * @param assigners - assigners bitmask
+ * @param new_assigner - new assigner service ID (for permission transfer)
  * @returns OK, CORE, HUH, or WHO
  */
 // @ts-expect-error: decorator
 @external("ecalli", "assign")
-export declare function assign(core: u32, auth_queue_ptr: u32, assigners: u32): i64;
+export declare function assign(core: u32, auth_queue_ptr: u32, new_assigner: u32): i64;

--- a/sdk/ecalli/accumulate/bless.ts
+++ b/sdk/ecalli/accumulate/bless.ts
@@ -1,25 +1,27 @@
 /**
  * Ecalli 14: Bless.
  *
- * Set the blessed/privileged service configuration.
+ * Set the blessed/privileged service configuration. Only the manager
+ * can change all fields; the delegator and registrar can each update
+ * only their own successor.
  *
  * Registers:
  * - r7  (in)  = m — manager service ID
  * - r7  (out)     — OK, HUH, or WHO
- * - r8  (in)  = a — auth queue memory address
+ * - r8  (in)  = a — assigners memory address (ServiceId per core)
  * - r9  (in)  = d — delegator service ID
  * - r10 (in)  = r — registrar service ID
- * - r11 (in)  = p — auto-accumulate services memory address
- * - r12 (in)  = n — auto-accumulate count
+ * - r11 (in)  = p — auto-accumulate entries memory address (ServiceId ++ Gas per entry)
+ * - r12 (in)  = n — auto-accumulate entry count
  *
  * @param manager - manager service ID
- * @param auth_queue_ptr - auth queue memory address
+ * @param assigners_ptr - assigners memory address (one ServiceId per core)
  * @param delegator - delegator service ID
  * @param registrar - registrar service ID
- * @param auto_accum_ptr - auto-accumulate services memory address
+ * @param auto_accum_ptr - auto-accumulate entries memory address
  * @param auto_accum_count - number of auto-accumulate entries
  * @returns OK, HUH, or WHO
  */
 // @ts-expect-error: decorator
 @external("ecalli", "bless")
-export declare function bless(manager: u32, auth_queue_ptr: u32, delegator: u32, registrar: u32, auto_accum_ptr: u32, auto_accum_count: u32): i64;
+export declare function bless(manager: u32, assigners_ptr: u32, delegator: u32, registrar: u32, auto_accum_ptr: u32, auto_accum_count: u32): i64;

--- a/sdk/jam/accumulate/admin.test.ts
+++ b/sdk/jam/accumulate/admin.test.ts
@@ -167,12 +167,7 @@ export const TESTS: Test[] = [
     const a = Assert.create();
     const admin = Admin.create();
 
-    const key = ValidatorKey.create(
-      Bytes32.zero(),
-      Bytes32.zero(),
-      BytesBlob.zero(144),
-      BytesBlob.zero(128),
-    );
+    const key = ValidatorKey.create(Bytes32.zero(), Bytes32.zero(), BytesBlob.zero(144), BytesBlob.zero(128));
     const result = admin.designate([key]);
     a.isEqual(result.isOkay, true, "should be ok");
     return a;

--- a/sdk/jam/accumulate/admin.test.ts
+++ b/sdk/jam/accumulate/admin.test.ts
@@ -102,6 +102,18 @@ export const TESTS: Test[] = [
     return a;
   }),
 
+  test("Admin.blessRegistrar returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setBlessResult(EcalliResult.HUH);
+    const result = admin.blessRegistrar(99);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, BlessError.Huh, "should be Huh");
+    return a;
+  }),
+
   // ─── assign ────────────────────────────────────────────────────────
 
   test("Admin.assign returns ok on success", () => {

--- a/sdk/jam/accumulate/admin.test.ts
+++ b/sdk/jam/accumulate/admin.test.ts
@@ -2,7 +2,7 @@ import { Bytes32, BytesBlob } from "../../core/bytes";
 import { EcalliResult } from "../../ecalli";
 import { TestEcalli, TestPrivileged } from "../../test/test-ecalli";
 import { Assert, Test, test } from "../../test/utils";
-import { AutoAccumulateEntry, ValidatorKey } from "../types";
+import { AutoAccumulateEntry, CURRENT_SERVICE, ValidatorKey } from "../types";
 import { Admin, AssignError, BlessError, DesignateError } from "./admin";
 
 export const TESTS: Test[] = [
@@ -132,23 +132,37 @@ export const TESTS: Test[] = [
 
   // ─── assign ────────────────────────────────────────────────────────
 
-  test("Admin.assign returns ok on success", () => {
+  test("Admin.assign encodes auth queue and uses default newAssigner", () => {
     TestEcalli.reset();
     const a = Assert.create();
     const admin = Admin.create();
 
-    const result = admin.assign(0, [Bytes32.zero()]);
+    const hash1 = Bytes32.zero();
+    hash1.raw[0] = 0xaa;
+    const hash2 = Bytes32.zero();
+    hash2.raw[0] = 0xbb;
+    const result = admin.assign(7, [hash1, hash2]);
     a.isEqual(result.isOkay, true, "should be ok");
+
+    // Verify scalar args
+    a.isEqual(TestPrivileged.getLastAssignCore(), 7, "core = 7");
+    a.isEqual(TestPrivileged.getLastAssignNewAssigner(), CURRENT_SERVICE, "default newAssigner = CURRENT_SERVICE");
+
+    // Verify auth queue encoding: 2 × Bytes32 = 64 bytes, sequential
+    const ptr = TestPrivileged.getLastAssignAuthQueuePtr();
+    a.isEqual(load<u8>(ptr), 0xaa, "hash1[0] = 0xaa");
+    a.isEqual(load<u8>(ptr + 32), 0xbb, "hash2[0] = 0xbb");
     return a;
   }),
 
-  test("Admin.assign with explicit newAssigner returns ok", () => {
+  test("Admin.assign with explicit newAssigner passes it through", () => {
     TestEcalli.reset();
     const a = Assert.create();
     const admin = Admin.create();
 
     const result = admin.assign(0, [Bytes32.zero()], 42);
-    a.isEqual(result.isOkay, true, "should be ok with explicit newAssigner");
+    a.isEqual(result.isOkay, true, "should be ok");
+    a.isEqual(TestPrivileged.getLastAssignNewAssigner(), 42, "newAssigner = 42");
     return a;
   }),
 
@@ -190,14 +204,30 @@ export const TESTS: Test[] = [
 
   // ─── designate ─────────────────────────────────────────────────────
 
-  test("Admin.designate returns ok on success", () => {
+  test("Admin.designate encodes validator keys", () => {
     TestEcalli.reset();
     const a = Assert.create();
     const admin = Admin.create();
 
-    const key = ValidatorKey.create(Bytes32.zero(), Bytes32.zero(), BytesBlob.zero(144), BytesBlob.zero(128));
+    const ed = Bytes32.zero();
+    ed.raw[0] = 0xe0;
+    const band = Bytes32.zero();
+    band.raw[0] = 0xb0;
+    const bls = BytesBlob.zero(144);
+    bls.raw[0] = 0xbb;
+    const meta = BytesBlob.zero(128);
+    meta.raw[0] = 0xaa;
+
+    const key = ValidatorKey.create(ed, band, bls, meta);
     const result = admin.designate([key]);
     a.isEqual(result.isOkay, true, "should be ok");
+
+    // Verify validators encoding: Ed25519(32) + Bandersnatch(32) + BLS(144) + metadata(128) = 336 bytes
+    const ptr = TestPrivileged.getLastDesignateValidatorsPtr();
+    a.isEqual(load<u8>(ptr), 0xe0, "ed25519[0] = 0xe0");
+    a.isEqual(load<u8>(ptr + 32), 0xb0, "bandersnatch[0] = 0xb0");
+    a.isEqual(load<u8>(ptr + 64), 0xbb, "bls[0] = 0xbb");
+    a.isEqual(load<u8>(ptr + 64 + 144), 0xaa, "metadata[0] = 0xaa");
     return a;
   }),
 

--- a/sdk/jam/accumulate/admin.test.ts
+++ b/sdk/jam/accumulate/admin.test.ts
@@ -1,0 +1,192 @@
+import { Bytes32, BytesBlob } from "../../core/bytes";
+import { EcalliResult } from "../../ecalli";
+import { TestEcalli, TestPrivileged } from "../../test/test-ecalli";
+import { Assert, Test, test } from "../../test/utils";
+import { AutoAccumulateEntry, ValidatorKey } from "../types";
+import { Admin, AssignError, BlessError, DesignateError } from "./admin";
+
+export const TESTS: Test[] = [
+  // ─── bless ─────────────────────────────────────────────────────────
+
+  test("Admin.bless returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    const result = admin.bless(1, [2, 3], 4, 5, [AutoAccumulateEntry.create(100, 500)]);
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("Admin.bless returns Who on WHO", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setBlessResult(EcalliResult.WHO);
+    const result = admin.bless(1, [], 4, 5, []);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, BlessError.Who, "should be Who");
+    return a;
+  }),
+
+  test("Admin.bless returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setBlessResult(EcalliResult.HUH);
+    const result = admin.bless(1, [], 4, 5, []);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, BlessError.Huh, "should be Huh");
+    return a;
+  }),
+
+  // ─── blessDelegator ────────────────────────────────────────────────
+
+  test("Admin.blessDelegator returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    const result = admin.blessDelegator(42);
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("Admin.blessDelegator returns Who on WHO", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setBlessResult(EcalliResult.WHO);
+    const result = admin.blessDelegator(42);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, BlessError.Who, "should be Who");
+    return a;
+  }),
+
+  test("Admin.blessDelegator returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setBlessResult(EcalliResult.HUH);
+    const result = admin.blessDelegator(42);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, BlessError.Huh, "should be Huh");
+    return a;
+  }),
+
+  // ─── blessRegistrar ────────────────────────────────────────────────
+
+  test("Admin.blessRegistrar returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    const result = admin.blessRegistrar(99);
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("Admin.blessRegistrar returns Who on WHO", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setBlessResult(EcalliResult.WHO);
+    const result = admin.blessRegistrar(99);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, BlessError.Who, "should be Who");
+    return a;
+  }),
+
+  // ─── assign ────────────────────────────────────────────────────────
+
+  test("Admin.assign returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    const result = admin.assign(0, [Bytes32.zero()]);
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("Admin.assign with explicit newAssigner returns ok", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    const result = admin.assign(0, [Bytes32.zero()], 42);
+    a.isEqual(result.isOkay, true, "should be ok with explicit newAssigner");
+    return a;
+  }),
+
+  test("Admin.assign returns Core on CORE", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setAssignResult(EcalliResult.CORE);
+    const result = admin.assign(999, []);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, AssignError.Core, "should be Core");
+    return a;
+  }),
+
+  test("Admin.assign returns Who on WHO", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setAssignResult(EcalliResult.WHO);
+    const result = admin.assign(0, []);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, AssignError.Who, "should be Who");
+    return a;
+  }),
+
+  test("Admin.assign returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setAssignResult(EcalliResult.HUH);
+    const result = admin.assign(0, []);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, AssignError.Huh, "should be Huh");
+    return a;
+  }),
+
+  // ─── designate ─────────────────────────────────────────────────────
+
+  test("Admin.designate returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    const key = ValidatorKey.create(
+      Bytes32.zero(),
+      Bytes32.zero(),
+      BytesBlob.zero(144),
+      BytesBlob.zero(128),
+    );
+    const result = admin.designate([key]);
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("Admin.designate returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const admin = Admin.create();
+
+    TestPrivileged.setDesignateResult(EcalliResult.HUH);
+    const result = admin.designate([]);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, DesignateError.Huh, "should be Huh");
+    return a;
+  }),
+];

--- a/sdk/jam/accumulate/admin.test.ts
+++ b/sdk/jam/accumulate/admin.test.ts
@@ -8,13 +8,29 @@ import { Admin, AssignError, BlessError, DesignateError } from "./admin";
 export const TESTS: Test[] = [
   // ─── bless ─────────────────────────────────────────────────────────
 
-  test("Admin.bless returns ok on success", () => {
+  test("Admin.bless encodes args and returns ok", () => {
     TestEcalli.reset();
     const a = Assert.create();
     const admin = Admin.create();
 
     const result = admin.bless(1, [2, 3], 4, 5, [AutoAccumulateEntry.create(100, 500)]);
     a.isEqual(result.isOkay, true, "should be ok");
+
+    // Verify scalar args passed through correctly
+    a.isEqual(TestPrivileged.getLastBlessManager(), 1, "manager");
+    a.isEqual(TestPrivileged.getLastBlessDelegator(), 4, "delegator");
+    a.isEqual(TestPrivileged.getLastBlessRegistrar(), 5, "registrar");
+    a.isEqual(TestPrivileged.getLastBlessAutoAccumCount(), 1, "autoAccum count");
+
+    // Verify assigners encoding: [2, 3] → 2 × u32 LE = 8 bytes
+    const aPtr = TestPrivileged.getLastBlessAssignersPtr();
+    a.isEqual(load<u32>(aPtr), 2, "assigners[0] = 2");
+    a.isEqual(load<u32>(aPtr + 4), 3, "assigners[1] = 3");
+
+    // Verify autoAccumulate encoding: [{ serviceId: 100, gas: 500 }] → u32 LE + u64 LE = 12 bytes
+    const aaPtr = TestPrivileged.getLastBlessAutoAccumPtr();
+    a.isEqual(load<u32>(aaPtr), 100, "autoAccum[0].serviceId = 100");
+    a.isEqual(load<u64>(aaPtr + 4), 500, "autoAccum[0].gas = 500");
     return a;
   }),
 

--- a/sdk/jam/accumulate/admin.ts
+++ b/sdk/jam/accumulate/admin.ts
@@ -1,0 +1,192 @@
+/**
+ * High-level wrappers for privileged governance ecallis (14-16).
+ *
+ * Each privilege role can only update its own field via bless:
+ * - The **manager** can change all fields (bless).
+ * - The **delegator** can transfer the delegator role (blessDelegator).
+ * - The **registrar** can transfer the registrar role (blessRegistrar).
+ */
+
+import { Bytes32, BytesBlob } from "../../core/bytes";
+import { Encoder } from "../../core/codec/encode";
+import { panic } from "../../core/panic";
+import { ResultN } from "../../core/result";
+import { EcalliResult } from "../../ecalli";
+import { assign as assign_ } from "../../ecalli/accumulate/assign";
+import { bless as bless_ } from "../../ecalli/accumulate/bless";
+import { designate as designate_ } from "../../ecalli/accumulate/designate";
+import {
+  AUTO_ACCUMULATE_ENTRY_SIZE,
+  AutoAccumulateEntry,
+  CURRENT_SERVICE,
+  CoreIndex,
+  ServiceId,
+  VALIDATOR_KEY_SIZE,
+  ValidatorKey,
+} from "../types";
+
+export enum BlessError {
+  /** Unknown service (WHO sentinel). */
+  Who = 0,
+  /** Invalid operation (HUH sentinel). */
+  Huh = 1,
+}
+
+export enum AssignError {
+  /** Unknown core (CORE sentinel). */
+  Core = 0,
+  /** Unknown service (WHO sentinel). */
+  Who = 1,
+  /** Invalid operation (HUH sentinel). */
+  Huh = 2,
+}
+
+export enum DesignateError {
+  /** Invalid operation (HUH sentinel). */
+  Huh = 0,
+}
+
+export class Admin {
+  static create(): Admin {
+    return new Admin();
+  }
+
+  private constructor() {}
+
+  /**
+   * Full bless — only callable by the manager service.
+   *
+   * Sets all privileged configuration: manager, per-core assigners,
+   * delegator, registrar, and auto-accumulate services.
+   *
+   * @param manager - new manager service ID
+   * @param assigners - assigner service ID for each core (one per core, flat array)
+   * @param delegator - new delegator service ID
+   * @param registrar - new registrar service ID
+   * @param autoAccumulate - auto-accumulate entries (service ID + gas pairs)
+   */
+  bless(
+    manager: ServiceId,
+    assigners: Array<ServiceId>,
+    delegator: ServiceId,
+    registrar: ServiceId,
+    autoAccumulate: Array<AutoAccumulateEntry>,
+  ): ResultN<bool, BlessError> {
+    const assignersBlob = encodeServiceIds(assigners);
+    const autoAccumBlob = encodeAutoAccumulate(autoAccumulate);
+    const result = bless_(
+      manager,
+      assignersBlob.ptr(),
+      delegator,
+      registrar,
+      autoAccumBlob.ptr(),
+      autoAccumulate.length,
+    );
+    return mapBlessResult(result);
+  }
+
+  /**
+   * Partial bless — callable by the current delegator to transfer the role.
+   *
+   * Only the delegator field is meaningful; the host ignores the rest.
+   */
+  blessDelegator(newDelegator: ServiceId): ResultN<bool, BlessError> {
+    const empty = BytesBlob.empty();
+    const result = bless_(0, empty.ptr(), newDelegator, 0, empty.ptr(), 0);
+    return mapBlessResult(result);
+  }
+
+  /**
+   * Partial bless — callable by the current registrar to transfer the role.
+   *
+   * Only the registrar field is meaningful; the host ignores the rest.
+   */
+  blessRegistrar(newRegistrar: ServiceId): ResultN<bool, BlessError> {
+    const empty = BytesBlob.empty();
+    const result = bless_(0, empty.ptr(), 0, newRegistrar, empty.ptr(), 0);
+    return mapBlessResult(result);
+  }
+
+  /**
+   * Assign an auth queue for a specific core (ecalli 15).
+   *
+   * Only callable by that core's assigner service (set via bless).
+   *
+   * @param core - core index
+   * @param authQueue - auth queue entries (code hashes for that core)
+   * @param newAssigner - transfer assigner permission (default: keep current service)
+   */
+  assign(
+    core: CoreIndex,
+    authQueue: Array<Bytes32>,
+    newAssigner: ServiceId = CURRENT_SERVICE,
+  ): ResultN<bool, AssignError> {
+    const authQueueBlob = encodeBytes32Array(authQueue);
+    const result = assign_(core, authQueueBlob.ptr(), newAssigner);
+    if (result === EcalliResult.CORE) return ResultN.err<bool, AssignError>(AssignError.Core);
+    if (result === EcalliResult.WHO) return ResultN.err<bool, AssignError>(AssignError.Who);
+    if (result === EcalliResult.HUH) return ResultN.err<bool, AssignError>(AssignError.Huh);
+    if (result >= 0) return ResultN.ok<bool, AssignError>(true);
+    panic("Admin.assign: unexpected sentinel");
+    return unreachable();
+  }
+
+  /**
+   * Set the next epoch's validator keys (ecalli 16).
+   *
+   * @param validators - array of validator keys
+   */
+  designate(validators: Array<ValidatorKey>): ResultN<bool, DesignateError> {
+    const blob = encodeValidators(validators);
+    const result = designate_(blob.ptr());
+    if (result === EcalliResult.HUH) return ResultN.err<bool, DesignateError>(DesignateError.Huh);
+    if (result >= 0) return ResultN.ok<bool, DesignateError>(true);
+    panic("Admin.designate: unexpected sentinel");
+    return unreachable();
+  }
+}
+
+function mapBlessResult(result: i64): ResultN<bool, BlessError> {
+  if (result === EcalliResult.WHO) return ResultN.err<bool, BlessError>(BlessError.Who);
+  if (result === EcalliResult.HUH) return ResultN.err<bool, BlessError>(BlessError.Huh);
+  if (result >= 0) return ResultN.ok<bool, BlessError>(true);
+  panic("Admin.bless: unexpected sentinel");
+  return unreachable();
+}
+
+function encodeServiceIds(ids: Array<ServiceId>): BytesBlob {
+  const enc = Encoder.create(ids.length * 4);
+  for (let i = 0; i < ids.length; i++) {
+    enc.u32(ids[i]);
+  }
+  return enc.finish();
+}
+
+function encodeAutoAccumulate(entries: Array<AutoAccumulateEntry>): BytesBlob {
+  const enc = Encoder.create(entries.length * AUTO_ACCUMULATE_ENTRY_SIZE);
+  for (let i = 0; i < entries.length; i++) {
+    enc.u32(entries[i].serviceId);
+    enc.u64(entries[i].gas);
+  }
+  return enc.finish();
+}
+
+function encodeBytes32Array(hashes: Array<Bytes32>): BytesBlob {
+  const enc = Encoder.create(hashes.length * 32);
+  for (let i = 0; i < hashes.length; i++) {
+    enc.bytes32(hashes[i]);
+  }
+  return enc.finish();
+}
+
+function encodeValidators(validators: Array<ValidatorKey>): BytesBlob {
+  const enc = Encoder.create(validators.length * VALIDATOR_KEY_SIZE);
+  for (let i = 0; i < validators.length; i++) {
+    const v = validators[i];
+    enc.bytes32(v.ed25519);
+    enc.bytes32(v.bandersnatch);
+    enc.bytesFixLen(v.bls);
+    enc.bytesFixLen(v.metadata);
+  }
+  return enc.finish();
+}

--- a/sdk/jam/accumulate/admin.ts
+++ b/sdk/jam/accumulate/admin.ts
@@ -18,8 +18,8 @@ import { designate as designate_ } from "../../ecalli/accumulate/designate";
 import {
   AUTO_ACCUMULATE_ENTRY_SIZE,
   AutoAccumulateEntry,
-  CURRENT_SERVICE,
   CoreIndex,
+  CURRENT_SERVICE,
   ServiceId,
   VALIDATOR_KEY_SIZE,
   ValidatorKey,
@@ -67,10 +67,10 @@ export class Admin {
    */
   bless(
     manager: ServiceId,
-    assigners: Array<ServiceId>,
+    assigners: ServiceId[],
     delegator: ServiceId,
     registrar: ServiceId,
-    autoAccumulate: Array<AutoAccumulateEntry>,
+    autoAccumulate: AutoAccumulateEntry[],
   ): ResultN<bool, BlessError> {
     const assignersBlob = encodeServiceIds(assigners);
     const autoAccumBlob = encodeAutoAccumulate(autoAccumulate);
@@ -116,11 +116,7 @@ export class Admin {
    * @param authQueue - auth queue entries (code hashes for that core)
    * @param newAssigner - transfer assigner permission (default: keep current service)
    */
-  assign(
-    core: CoreIndex,
-    authQueue: Array<Bytes32>,
-    newAssigner: ServiceId = CURRENT_SERVICE,
-  ): ResultN<bool, AssignError> {
+  assign(core: CoreIndex, authQueue: Bytes32[], newAssigner: ServiceId = CURRENT_SERVICE): ResultN<bool, AssignError> {
     const authQueueBlob = encodeBytes32Array(authQueue);
     const result = assign_(core, authQueueBlob.ptr(), newAssigner);
     if (result === EcalliResult.CORE) return ResultN.err<bool, AssignError>(AssignError.Core);
@@ -136,7 +132,7 @@ export class Admin {
    *
    * @param validators - array of validator keys
    */
-  designate(validators: Array<ValidatorKey>): ResultN<bool, DesignateError> {
+  designate(validators: ValidatorKey[]): ResultN<bool, DesignateError> {
     const blob = encodeValidators(validators);
     const result = designate_(blob.ptr());
     if (result === EcalliResult.HUH) return ResultN.err<bool, DesignateError>(DesignateError.Huh);
@@ -154,7 +150,7 @@ function mapBlessResult(result: i64): ResultN<bool, BlessError> {
   return unreachable();
 }
 
-function encodeServiceIds(ids: Array<ServiceId>): BytesBlob {
+function encodeServiceIds(ids: ServiceId[]): BytesBlob {
   const enc = Encoder.create(ids.length * 4);
   for (let i = 0; i < ids.length; i++) {
     enc.u32(ids[i]);
@@ -162,7 +158,7 @@ function encodeServiceIds(ids: Array<ServiceId>): BytesBlob {
   return enc.finish();
 }
 
-function encodeAutoAccumulate(entries: Array<AutoAccumulateEntry>): BytesBlob {
+function encodeAutoAccumulate(entries: AutoAccumulateEntry[]): BytesBlob {
   const enc = Encoder.create(entries.length * AUTO_ACCUMULATE_ENTRY_SIZE);
   for (let i = 0; i < entries.length; i++) {
     enc.u32(entries[i].serviceId);
@@ -171,7 +167,7 @@ function encodeAutoAccumulate(entries: Array<AutoAccumulateEntry>): BytesBlob {
   return enc.finish();
 }
 
-function encodeBytes32Array(hashes: Array<Bytes32>): BytesBlob {
+function encodeBytes32Array(hashes: Bytes32[]): BytesBlob {
   const enc = Encoder.create(hashes.length * 32);
   for (let i = 0; i < hashes.length; i++) {
     enc.bytes32(hashes[i]);
@@ -179,7 +175,7 @@ function encodeBytes32Array(hashes: Array<Bytes32>): BytesBlob {
   return enc.finish();
 }
 
-function encodeValidators(validators: Array<ValidatorKey>): BytesBlob {
+function encodeValidators(validators: ValidatorKey[]): BytesBlob {
   const enc = Encoder.create(validators.length * VALIDATOR_KEY_SIZE);
   for (let i = 0; i < validators.length; i++) {
     const v = validators[i];

--- a/sdk/jam/accumulate/child-services.test.ts
+++ b/sdk/jam/accumulate/child-services.test.ts
@@ -15,7 +15,7 @@ export const TESTS: Test[] = [
     const result = cs.newChild(Bytes32.zero(), 1024, 10_000, 50_000);
     a.isEqual(result.isOkay, true, "should be ok");
     // Default mock returns incrementing IDs starting from 256
-    a.isEqual(result.okay >= 256, true, "service ID >= 256");
+    a.isEqual(result.okay, 256, "first service ID after reset = 256");
     return a;
   }),
 

--- a/sdk/jam/accumulate/child-services.test.ts
+++ b/sdk/jam/accumulate/child-services.test.ts
@@ -1,0 +1,93 @@
+import { Bytes32 } from "../../core/bytes";
+import { EcalliResult } from "../../ecalli";
+import { TestEcalli, TestServices } from "../../test/test-ecalli";
+import { Assert, Test, test } from "../../test/utils";
+import { ChildServices, EjectChildError, NewChildError } from "./child-services";
+
+export const TESTS: Test[] = [
+  // ─── newChild ──────────────────────────────────────────────────────
+
+  test("ChildServices.newChild returns service ID on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    const result = cs.newChild(Bytes32.zero(), 1024, 10_000, 50_000);
+    a.isEqual(result.isOkay, true, "should be ok");
+    // Default mock returns incrementing IDs starting from 256
+    a.isEqual(result.okay >= 256, true, "service ID >= 256");
+    return a;
+  }),
+
+  test("ChildServices.newChild returns Cash on CASH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    TestServices.setNewServiceResult(EcalliResult.CASH);
+    const result = cs.newChild(Bytes32.zero(), 1024, 10_000, 50_000);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, NewChildError.Cash, "should be Cash");
+    return a;
+  }),
+
+  test("ChildServices.newChild returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    TestServices.setNewServiceResult(EcalliResult.HUH);
+    const result = cs.newChild(Bytes32.zero(), 1024, 10_000, 50_000);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, NewChildError.Huh, "should be Huh");
+    return a;
+  }),
+
+  test("ChildServices.newChild returns Full on FULL", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    TestServices.setNewServiceResult(EcalliResult.FULL);
+    const result = cs.newChild(Bytes32.zero(), 1024, 10_000, 50_000);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, NewChildError.Full, "should be Full");
+    return a;
+  }),
+
+  // ─── ejectChild ───────────────────────────────────────────────────
+
+  test("ChildServices.ejectChild returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    const result = cs.ejectChild(100, Bytes32.zero());
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("ChildServices.ejectChild returns Who on WHO", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    TestServices.setEjectResult(EcalliResult.WHO);
+    const result = cs.ejectChild(100, Bytes32.zero());
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, EjectChildError.Who, "should be Who");
+    return a;
+  }),
+
+  test("ChildServices.ejectChild returns Huh on HUH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const cs = ChildServices.create();
+
+    TestServices.setEjectResult(EcalliResult.HUH);
+    const result = cs.ejectChild(100, Bytes32.zero());
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, EjectChildError.Huh, "should be Huh");
+    return a;
+  }),
+];

--- a/sdk/jam/accumulate/child-services.ts
+++ b/sdk/jam/accumulate/child-services.ts
@@ -1,0 +1,87 @@
+/**
+ * High-level wrappers for child service lifecycle ecallis (18, 21).
+ *
+ * The current service can create new child services and eject existing ones.
+ */
+
+import { Bytes32 } from "../../core/bytes";
+import { panic } from "../../core/panic";
+import { ResultN } from "../../core/result";
+import { EcalliResult } from "../../ecalli";
+import { eject } from "../../ecalli/accumulate/eject";
+import { new_service } from "../../ecalli/accumulate/new_service";
+import { CodeHash, ServiceId } from "../types";
+
+export enum NewChildError {
+  /** Insufficient funds (CASH sentinel). */
+  Cash = 0,
+  /** Invalid operation (HUH sentinel). */
+  Huh = 1,
+  /** Storage full (FULL sentinel). */
+  Full = 2,
+}
+
+export enum EjectChildError {
+  /** Unknown service (WHO sentinel). */
+  Who = 0,
+  /** Invalid operation (HUH sentinel). */
+  Huh = 1,
+}
+
+export class ChildServices {
+  static create(): ChildServices {
+    return new ChildServices();
+  }
+
+  private constructor() {}
+
+  /**
+   * Create a new child service (ecalli 18).
+   *
+   * @param codeHash - blake2b hash of the service code
+   * @param codeLen - length of the service code
+   * @param gas - minimum accumulate gas for the new service
+   * @param allowance - initial token allowance
+   * @param gratisStorage - free storage bytes (default 0)
+   * @param requestedId - specific service ID to request (default: auto-assign)
+   * @returns the new service ID on success, or NewChildError
+   */
+  newChild(
+    codeHash: CodeHash,
+    codeLen: u32,
+    gas: u64,
+    allowance: u64,
+    gratisStorage: u32 = 0,
+    requestedId: ServiceId = u32.MAX_VALUE,
+  ): ResultN<ServiceId, NewChildError> {
+    const result = new_service(codeHash.ptr(), codeLen, gas, allowance, gratisStorage, requestedId);
+    if (result === EcalliResult.CASH) return ResultN.err<ServiceId, NewChildError>(NewChildError.Cash);
+    if (result === EcalliResult.HUH) return ResultN.err<ServiceId, NewChildError>(NewChildError.Huh);
+    if (result === EcalliResult.FULL) return ResultN.err<ServiceId, NewChildError>(NewChildError.Full);
+    if (result >= 0) return ResultN.ok<ServiceId, NewChildError>(u32(result));
+    panic("ChildServices.newChild: unexpected sentinel");
+    return unreachable();
+  }
+
+  /**
+   * Eject (remove) a child service (ecalli 21).
+   *
+   * The child service must have previously called `requestEjection` to
+   * signal readiness by upgrading its code hash to the ejection hash.
+   *
+   * @param serviceId - service to eject
+   * @param prevCodeHash - the service's current code hash (for host verification)
+   * @returns ok(true) on success, or EjectChildError
+   */
+  ejectChild(
+    serviceId: ServiceId,
+    prevCodeHash: CodeHash,
+  ): ResultN<bool, EjectChildError> {
+    const result = eject(serviceId, prevCodeHash.ptr());
+    if (result === EcalliResult.WHO) return ResultN.err<bool, EjectChildError>(EjectChildError.Who);
+    if (result === EcalliResult.HUH) return ResultN.err<bool, EjectChildError>(EjectChildError.Huh);
+    if (result >= 0) return ResultN.ok<bool, EjectChildError>(true);
+    panic("ChildServices.ejectChild: unexpected sentinel");
+    return unreachable();
+  }
+}

--- a/sdk/jam/accumulate/child-services.ts
+++ b/sdk/jam/accumulate/child-services.ts
@@ -4,7 +4,6 @@
  * The current service can create new child services and eject existing ones.
  */
 
-import { Bytes32 } from "../../core/bytes";
 import { panic } from "../../core/panic";
 import { ResultN } from "../../core/result";
 import { EcalliResult } from "../../ecalli";
@@ -73,10 +72,7 @@ export class ChildServices {
    * @param prevCodeHash - the service's current code hash (for host verification)
    * @returns ok(true) on success, or EjectChildError
    */
-  ejectChild(
-    serviceId: ServiceId,
-    prevCodeHash: CodeHash,
-  ): ResultN<bool, EjectChildError> {
+  ejectChild(serviceId: ServiceId, prevCodeHash: CodeHash): ResultN<bool, EjectChildError> {
     const result = eject(serviceId, prevCodeHash.ptr());
     if (result === EcalliResult.WHO) return ResultN.err<bool, EjectChildError>(EjectChildError.Who);
     if (result === EcalliResult.HUH) return ResultN.err<bool, EjectChildError>(EjectChildError.Huh);

--- a/sdk/jam/accumulate/context.ts
+++ b/sdk/jam/accumulate/context.ts
@@ -110,12 +110,7 @@ export class AccumulateContext {
    * @param memo - optional 128-byte memo (default: all zeros)
    * @returns ok(true) on success, or TransferError
    */
-  scheduleTransfer(
-    dest: ServiceId,
-    amount: u64,
-    gasFee: u64,
-    memo: Memo | null = null,
-  ): ResultN<bool, TransferError> {
+  scheduleTransfer(dest: ServiceId, amount: u64, gasFee: u64, memo: Memo | null = null): ResultN<bool, TransferError> {
     const m = memo !== null ? memo : Memo.empty();
     const result = transfer_(dest, amount, gasFee, m.ptr());
     if (result === EcalliResult.WHO) return ResultN.err<bool, TransferError>(TransferError.Who);

--- a/sdk/jam/accumulate/context.ts
+++ b/sdk/jam/accumulate/context.ts
@@ -13,9 +13,23 @@ import { Encoder } from "../../core/codec/encode";
 import { readFromMemory } from "../../core/mem";
 import { ptrAndLen } from "../../core/pack";
 import { panic } from "../../core/panic";
+import { ResultN } from "../../core/result";
+import { EcalliResult } from "../../ecalli";
 import { checkpoint as checkpoint_, yield_result } from "../../ecalli/accumulate";
+import { transfer as transfer_ } from "../../ecalli/accumulate/transfer";
 import { AccumulateArgs, AccumulateArgsCodec, OptionalCodeHashCodec, Response, ResponseCodec } from "../service";
+import { ServiceId } from "../types";
 import { AccumulateItemCodec, OperandCodec, PendingTransferCodec, WorkExecResultCodec } from "./item";
+import { Memo } from "./memo";
+
+export enum TransferError {
+  /** Unknown destination service (WHO sentinel). */
+  Who = 0,
+  /** Gas limit too low (LOW sentinel). */
+  Low = 1,
+  /** Insufficient funds (CASH sentinel). */
+  Cash = 2,
+}
 
 export class AccumulateContext {
   static create(): AccumulateContext {
@@ -83,6 +97,33 @@ export class AccumulateContext {
    */
   yieldResult(hash: Bytes32): void {
     yield_result(hash.ptr());
+  }
+
+  /**
+   * Schedule a balance transfer to another service (ecalli 20).
+   *
+   * The transfer is not instant — it is executed after accumulation completes.
+   *
+   * @param dest - destination service ID
+   * @param amount - transfer amount
+   * @param gasFee - gas fee limit for the transfer
+   * @param memo - optional 128-byte memo (default: all zeros)
+   * @returns ok(true) on success, or TransferError
+   */
+  scheduleTransfer(
+    dest: ServiceId,
+    amount: u64,
+    gasFee: u64,
+    memo: Memo | null = null,
+  ): ResultN<bool, TransferError> {
+    const m = memo !== null ? memo : Memo.empty();
+    const result = transfer_(dest, amount, gasFee, m.ptr());
+    if (result === EcalliResult.WHO) return ResultN.err<bool, TransferError>(TransferError.Who);
+    if (result === EcalliResult.LOW) return ResultN.err<bool, TransferError>(TransferError.Low);
+    if (result === EcalliResult.CASH) return ResultN.err<bool, TransferError>(TransferError.Cash);
+    if (result >= 0) return ResultN.ok<bool, TransferError>(true);
+    panic("AccumulateContext.scheduleTransfer: unexpected sentinel");
+    return unreachable();
   }
 
   /** Parse raw accumulate arguments from (ptr, len). Panics on invalid data. */

--- a/sdk/jam/accumulate/index.ts
+++ b/sdk/jam/accumulate/index.ts
@@ -1,4 +1,8 @@
-export { AccumulateContext } from "./context";
+export { Admin, AssignError, BlessError, DesignateError } from "./admin";
+export { ChildServices, EjectChildError, NewChildError } from "./child-services";
+export { AccumulateContext, TransferError } from "./context";
 export { AccumulateFetcher } from "./fetcher";
 export * from "./item";
+export { Memo } from "./memo";
 export { AccumulatePreimages, ForgetError, ProvideError, SolicitError } from "./preimages";
+export { SelfService } from "./self-service";

--- a/sdk/jam/accumulate/memo.ts
+++ b/sdk/jam/accumulate/memo.ts
@@ -1,0 +1,44 @@
+/**
+ * Fixed-size 128-byte memo for transfers.
+ *
+ * Shorter input is zero-padded to 128 bytes. Input exceeding 128 bytes
+ * is silently truncated.
+ */
+
+import { BytesBlob } from "../../core/bytes";
+import { TRANSFER_MEMO_SIZE } from "./item";
+
+export { TRANSFER_MEMO_SIZE };
+
+export class Memo {
+  /**
+   * Create a memo from arbitrary data.
+   *
+   * If data is shorter than 128 bytes it is zero-padded.
+   * If data is longer than 128 bytes it is truncated.
+   */
+  static create(data: BytesBlob): Memo {
+    if (<u32>data.length === TRANSFER_MEMO_SIZE) {
+      return new Memo(data);
+    }
+    const padded = BytesBlob.zero(TRANSFER_MEMO_SIZE);
+    const copyLen = min<u32>(<u32>data.length, TRANSFER_MEMO_SIZE);
+    memory.copy(padded.raw.dataStart, data.raw.dataStart, copyLen);
+    return new Memo(padded);
+  }
+
+  /** Create an empty memo (128 zero bytes). */
+  static empty(): Memo {
+    return new Memo(BytesBlob.zero(TRANSFER_MEMO_SIZE));
+  }
+
+  private constructor(
+    /** The 128-byte memo data. */
+    public readonly data: BytesBlob,
+  ) {}
+
+  /** Pointer to the underlying memory (for ecalli calls). */
+  ptr(): u32 {
+    return this.data.ptr();
+  }
+}

--- a/sdk/jam/accumulate/self-service.test.ts
+++ b/sdk/jam/accumulate/self-service.test.ts
@@ -1,0 +1,52 @@
+import { Bytes32 } from "../../core/bytes";
+import { TestEcalli } from "../../test/test-ecalli";
+import { Assert, Test, test } from "../../test/utils";
+import { SelfService } from "./self-service";
+
+export const TESTS: Test[] = [
+  test("SelfService.upgradeCode does not panic", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const svc = SelfService.create();
+
+    svc.upgradeCode(Bytes32.zero(), 10_000, 50_000);
+    a.isEqual(true, true, "upgradeCode completed");
+    return a;
+  }),
+
+  test("SelfService.requestEjection builds correct ejection hash", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const svc = SelfService.create();
+
+    // Verify the ejection hash is parentServiceId as LE u32 zero-padded to 32 bytes.
+    // We can't intercept the ecalli call directly, but we can verify the hash
+    // construction logic by building the expected hash manually.
+    const parentId: u32 = 0x01020304;
+    const expected = Bytes32.zero();
+    store<u32>(expected.raw.dataStart, parentId);
+    // First 4 bytes should be LE encoding of 0x01020304
+    a.isEqual(expected.raw[0], 0x04, "byte 0 = LE low byte");
+    a.isEqual(expected.raw[1], 0x03, "byte 1");
+    a.isEqual(expected.raw[2], 0x02, "byte 2");
+    a.isEqual(expected.raw[3], 0x01, "byte 3 = LE high byte");
+    // Remaining bytes should be zero
+    a.isEqual(expected.raw[4], 0, "byte 4 = 0");
+    a.isEqual(expected.raw[31], 0, "byte 31 = 0");
+
+    // The actual call should not panic
+    svc.requestEjection(parentId);
+    a.isEqual(true, true, "requestEjection completed");
+    return a;
+  }),
+
+  test("SelfService.requestEjection with service ID 0", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const svc = SelfService.create();
+
+    svc.requestEjection(0);
+    a.isEqual(true, true, "requestEjection with 0 completed");
+    return a;
+  }),
+];

--- a/sdk/jam/accumulate/self-service.test.ts
+++ b/sdk/jam/accumulate/self-service.test.ts
@@ -1,42 +1,47 @@
 import { Bytes32 } from "../../core/bytes";
-import { TestEcalli } from "../../test/test-ecalli";
+import { TestEcalli, TestServices } from "../../test/test-ecalli";
 import { Assert, Test, test } from "../../test/utils";
 import { SelfService } from "./self-service";
 
 export const TESTS: Test[] = [
-  test("SelfService.upgradeCode does not panic", () => {
+  test("SelfService.upgradeCode passes correct args to upgrade ecalli", () => {
     TestEcalli.reset();
     const a = Assert.create();
     const svc = SelfService.create();
 
-    svc.upgradeCode(Bytes32.zero(), 10_000, 50_000);
-    a.isEqual(true, true, "upgradeCode completed");
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0xaa;
+    hash.raw[31] = 0xbb;
+    svc.upgradeCode(hash, 10_000, 50_000);
+
+    const ptr = TestServices.getLastUpgradeCodeHashPtr();
+    a.isEqual(load<u8>(ptr), 0xaa, "code hash byte 0");
+    a.isEqual(load<u8>(ptr + 31), 0xbb, "code hash byte 31");
+    a.isEqual(TestServices.getLastUpgradeGas(), 10_000, "gas");
+    a.isEqual(TestServices.getLastUpgradeAllowance(), 50_000, "allowance");
     return a;
   }),
 
-  test("SelfService.requestEjection builds correct ejection hash", () => {
+  test("SelfService.requestEjection sends correct ejection hash", () => {
     TestEcalli.reset();
     const a = Assert.create();
     const svc = SelfService.create();
 
-    // Verify the ejection hash is parentServiceId as LE u32 zero-padded to 32 bytes.
-    // We can't intercept the ecalli call directly, but we can verify the hash
-    // construction logic by building the expected hash manually.
     const parentId: u32 = 0x01020304;
-    const expected = Bytes32.zero();
-    store<u32>(expected.raw.dataStart, parentId);
-    // First 4 bytes should be LE encoding of 0x01020304
-    a.isEqual(expected.raw[0], 0x04, "byte 0 = LE low byte");
-    a.isEqual(expected.raw[1], 0x03, "byte 1");
-    a.isEqual(expected.raw[2], 0x02, "byte 2");
-    a.isEqual(expected.raw[3], 0x01, "byte 3 = LE high byte");
-    // Remaining bytes should be zero
-    a.isEqual(expected.raw[4], 0, "byte 4 = 0");
-    a.isEqual(expected.raw[31], 0, "byte 31 = 0");
-
-    // The actual call should not panic
     svc.requestEjection(parentId);
-    a.isEqual(true, true, "requestEjection completed");
+
+    // Verify the code hash passed to upgrade is parentId as LE u32, zero-padded to 32 bytes
+    const ptr = TestServices.getLastUpgradeCodeHashPtr();
+    a.isEqual(load<u8>(ptr), 0x04, "byte 0 = LE low byte");
+    a.isEqual(load<u8>(ptr + 1), 0x03, "byte 1");
+    a.isEqual(load<u8>(ptr + 2), 0x02, "byte 2");
+    a.isEqual(load<u8>(ptr + 3), 0x01, "byte 3 = LE high byte");
+    a.isEqual(load<u8>(ptr + 4), 0, "byte 4 = 0 (zero-padded)");
+    a.isEqual(load<u8>(ptr + 31), 0, "byte 31 = 0 (zero-padded)");
+
+    // Verify gas and allowance are both 0
+    a.isEqual(TestServices.getLastUpgradeGas(), 0, "gas = 0");
+    a.isEqual(TestServices.getLastUpgradeAllowance(), 0, "allowance = 0");
     return a;
   }),
 
@@ -46,7 +51,12 @@ export const TESTS: Test[] = [
     const svc = SelfService.create();
 
     svc.requestEjection(0);
-    a.isEqual(true, true, "requestEjection with 0 completed");
+
+    const ptr = TestServices.getLastUpgradeCodeHashPtr();
+    // All 32 bytes should be zero
+    a.isEqual(load<u8>(ptr), 0, "byte 0 = 0");
+    a.isEqual(load<u8>(ptr + 3), 0, "byte 3 = 0");
+    a.isEqual(load<u8>(ptr + 31), 0, "byte 31 = 0");
     return a;
   }),
 ];

--- a/sdk/jam/accumulate/self-service.ts
+++ b/sdk/jam/accumulate/self-service.ts
@@ -1,0 +1,57 @@
+/**
+ * High-level wrappers for service self-management (ecalli 19: upgrade).
+ *
+ * Provides two distinct operations:
+ * - {@link upgradeCode} — upgrade to new service code.
+ * - {@link requestEjection} — signal readiness for ejection by a parent service.
+ */
+
+import { Bytes32 } from "../../core/bytes";
+import { upgrade } from "../../ecalli/accumulate/upgrade";
+import { ServiceId } from "../types";
+
+export class SelfService {
+  static create(): SelfService {
+    return new SelfService();
+  }
+
+  private constructor() {}
+
+  /**
+   * Upgrade the current service's code (ecalli 19).
+   *
+   * Always succeeds (the host always returns OK).
+   *
+   * **Important:** The caller must ensure the preimage for `codeHash` is
+   * available in state (e.g. via `AccumulatePreimages.provide` or `solicit`)
+   * before the next accumulation. If the preimage is missing, the service
+   * will be non-functional.
+   *
+   * @param codeHash - blake2b hash of the new service code
+   * @param gas - new minimum accumulate gas
+   * @param allowance - new token allowance
+   */
+  upgradeCode(codeHash: Bytes32, gas: u64, allowance: u64): void {
+    upgrade(codeHash.ptr(), gas, allowance);
+  }
+
+  /**
+   * Request ejection from a parent service (ecalli 19).
+   *
+   * Calls upgrade with a special "ejection hash" derived from the parent
+   * service ID: the parent ID as 4 LE bytes, zero-padded to 32 bytes.
+   * Gas and allowance are both set to 0.
+   *
+   * **Important:** Before calling this, the service should clear all its
+   * storage to avoid losing tokens locked in storage deposits. There is
+   * no programmatic way to verify storage is empty — this is the caller's
+   * responsibility.
+   *
+   * @param parentServiceId - the parent service that should eject this service
+   */
+  requestEjection(parentServiceId: ServiceId): void {
+    const hash = Bytes32.zero();
+    store<u32>(hash.raw.dataStart, parentServiceId);
+    upgrade(hash.ptr(), 0, 0);
+  }
+}

--- a/sdk/jam/accumulate/transfer.test.ts
+++ b/sdk/jam/accumulate/transfer.test.ts
@@ -1,0 +1,127 @@
+import { BytesBlob } from "../../core/bytes";
+import { EcalliResult } from "../../ecalli";
+import { TestEcalli, TestTransfer } from "../../test/test-ecalli";
+import { Assert, Test, test } from "../../test/utils";
+import { AccumulateContext, TransferError } from "./context";
+import { TRANSFER_MEMO_SIZE } from "./item";
+import { Memo } from "./memo";
+
+export const TESTS: Test[] = [
+  // ─── Memo ──────────────────────────────────────────────────────────
+
+  test("Memo.empty creates 128 zero bytes", () => {
+    const a = Assert.create();
+    const memo = Memo.empty();
+    a.isEqual(<u32>memo.data.length, TRANSFER_MEMO_SIZE, "length = 128");
+    a.isEqual(memo.data.raw[0], 0, "first byte = 0");
+    a.isEqual(memo.data.raw[127], 0, "last byte = 0");
+    return a;
+  }),
+
+  test("Memo.create pads short data to 128 bytes", () => {
+    const a = Assert.create();
+    const short = BytesBlob.parseBlob("0xdeadbeef").okay!;
+    const memo = Memo.create(short);
+    a.isEqual(<u32>memo.data.length, TRANSFER_MEMO_SIZE, "length = 128");
+    a.isEqual(memo.data.raw[0], 0xde, "byte 0 preserved");
+    a.isEqual(memo.data.raw[1], 0xad, "byte 1 preserved");
+    a.isEqual(memo.data.raw[2], 0xbe, "byte 2 preserved");
+    a.isEqual(memo.data.raw[3], 0xef, "byte 3 preserved");
+    a.isEqual(memo.data.raw[4], 0, "byte 4 = 0 (padded)");
+    a.isEqual(memo.data.raw[127], 0, "byte 127 = 0 (padded)");
+    return a;
+  }),
+
+  test("Memo.create truncates long data to 128 bytes", () => {
+    const a = Assert.create();
+    const long = BytesBlob.zero(200);
+    for (let i: u32 = 0; i < 200; i++) long.raw[i] = u8(i & 0xff);
+    const memo = Memo.create(long);
+    a.isEqual(<u32>memo.data.length, TRANSFER_MEMO_SIZE, "length = 128");
+    a.isEqual(memo.data.raw[0], 0, "byte 0 preserved");
+    a.isEqual(memo.data.raw[127], 127, "byte 127 preserved");
+    return a;
+  }),
+
+  test("Memo.create with exact 128 bytes wraps directly", () => {
+    const a = Assert.create();
+    const exact = BytesBlob.zero(TRANSFER_MEMO_SIZE);
+    exact.raw[0] = 0xaa;
+    exact.raw[127] = 0xbb;
+    const memo = Memo.create(exact);
+    a.isEqual(<u32>memo.data.length, TRANSFER_MEMO_SIZE, "length = 128");
+    a.isEqual(memo.data.raw[0], 0xaa, "byte 0");
+    a.isEqual(memo.data.raw[127], 0xbb, "byte 127");
+    return a;
+  }),
+
+  // ─── scheduleTransfer ──────────────────────────────────────────────
+
+  test("scheduleTransfer returns ok on success", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const ctx = AccumulateContext.create();
+
+    const result = ctx.scheduleTransfer(100, 5000, 100);
+    a.isEqual(result.isOkay, true, "should be ok");
+    return a;
+  }),
+
+  test("scheduleTransfer returns Who on WHO", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const ctx = AccumulateContext.create();
+
+    TestTransfer.setTransferResult(EcalliResult.WHO);
+    const result = ctx.scheduleTransfer(999, 5000, 100);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, TransferError.Who, "should be Who");
+    return a;
+  }),
+
+  test("scheduleTransfer returns Low on LOW", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const ctx = AccumulateContext.create();
+
+    TestTransfer.setTransferResult(EcalliResult.LOW);
+    const result = ctx.scheduleTransfer(100, 5000, 1);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, TransferError.Low, "should be Low");
+    return a;
+  }),
+
+  test("scheduleTransfer returns Cash on CASH", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const ctx = AccumulateContext.create();
+
+    TestTransfer.setTransferResult(EcalliResult.CASH);
+    const result = ctx.scheduleTransfer(100, 999_999_999, 100);
+    a.isEqual(result.isError, true, "should be error");
+    a.isEqual(result.error, TransferError.Cash, "should be Cash");
+    return a;
+  }),
+
+  test("scheduleTransfer uses zero memo when none provided", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const ctx = AccumulateContext.create();
+
+    // Should succeed with default null memo (128 zero bytes)
+    const result = ctx.scheduleTransfer(100, 5000, 100);
+    a.isEqual(result.isOkay, true, "should be ok with null memo");
+    return a;
+  }),
+
+  test("scheduleTransfer accepts explicit Memo", () => {
+    TestEcalli.reset();
+    const a = Assert.create();
+    const ctx = AccumulateContext.create();
+
+    const memo = Memo.create(BytesBlob.parseBlob("0xdeadbeef").okay!);
+    const result = ctx.scheduleTransfer(100, 5000, 100, memo);
+    a.isEqual(result.isOkay, true, "should be ok with explicit memo");
+    return a;
+  }),
+];

--- a/sdk/jam/types.ts
+++ b/sdk/jam/types.ts
@@ -42,12 +42,7 @@ export const VALIDATOR_KEY_SIZE: u32 = 336;
  * Validator key: Ed25519(32) + Bandersnatch(32) + BLS(144) + metadata(128) = 336 bytes.
  */
 export class ValidatorKey {
-  static create(
-    ed25519: Bytes32,
-    bandersnatch: Bytes32,
-    bls: BytesBlob,
-    metadata: BytesBlob,
-  ): ValidatorKey {
+  static create(ed25519: Bytes32, bandersnatch: Bytes32, bls: BytesBlob, metadata: BytesBlob): ValidatorKey {
     assert(<u32>bls.length === BLS_KEY_SIZE, `bls must be ${BLS_KEY_SIZE} bytes, got ${bls.length}`);
     assert(
       <u32>metadata.length === VALIDATOR_METADATA_SIZE,

--- a/sdk/jam/types.ts
+++ b/sdk/jam/types.ts
@@ -24,3 +24,61 @@ export const CURRENT_SERVICE: ServiceId = u32.MAX_VALUE;
 export type WorkPayload = BytesBlob;
 export type AuthOutput = BytesBlob;
 export type WorkOutput = BytesBlob;
+
+// ─── Validator keys ──────────────────────────────────────────────────
+
+/** Ed25519 key size in bytes. */
+export const ED25519_KEY_SIZE: u32 = 32;
+/** Bandersnatch key size in bytes. */
+export const BANDERSNATCH_KEY_SIZE: u32 = 32;
+/** BLS key size in bytes. */
+export const BLS_KEY_SIZE: u32 = 144;
+/** Validator metadata size in bytes. */
+export const VALIDATOR_METADATA_SIZE: u32 = 128;
+/** Total size of a single ValidatorKey entry in bytes. */
+export const VALIDATOR_KEY_SIZE: u32 = 336;
+
+/**
+ * Validator key: Ed25519(32) + Bandersnatch(32) + BLS(144) + metadata(128) = 336 bytes.
+ */
+export class ValidatorKey {
+  static create(
+    ed25519: Bytes32,
+    bandersnatch: Bytes32,
+    bls: BytesBlob,
+    metadata: BytesBlob,
+  ): ValidatorKey {
+    assert(<u32>bls.length === BLS_KEY_SIZE, `bls must be ${BLS_KEY_SIZE} bytes, got ${bls.length}`);
+    assert(
+      <u32>metadata.length === VALIDATOR_METADATA_SIZE,
+      `metadata must be ${VALIDATOR_METADATA_SIZE} bytes, got ${metadata.length}`,
+    );
+    return new ValidatorKey(ed25519, bandersnatch, bls, metadata);
+  }
+
+  private constructor(
+    public readonly ed25519: Bytes32,
+    public readonly bandersnatch: Bytes32,
+    public readonly bls: BytesBlob,
+    public readonly metadata: BytesBlob,
+  ) {}
+}
+
+// ─── Auto-accumulate entry ───────────────────────────────────────────
+
+/** Auto-accumulate entry size: ServiceId(u32) + Gas(u64) = 12 bytes. */
+export const AUTO_ACCUMULATE_ENTRY_SIZE: u32 = 12;
+
+/**
+ * An auto-accumulate service entry: service ID + minimum gas.
+ */
+export class AutoAccumulateEntry {
+  static create(serviceId: ServiceId, gas: u64): AutoAccumulateEntry {
+    return new AutoAccumulateEntry(serviceId, gas);
+  }
+
+  private constructor(
+    public readonly serviceId: ServiceId,
+    public readonly gas: u64,
+  ) {}
+}

--- a/sdk/jam/types.ts
+++ b/sdk/jam/types.ts
@@ -36,7 +36,8 @@ export const BLS_KEY_SIZE: u32 = 144;
 /** Validator metadata size in bytes. */
 export const VALIDATOR_METADATA_SIZE: u32 = 128;
 /** Total size of a single ValidatorKey entry in bytes. */
-export const VALIDATOR_KEY_SIZE: u32 = 336;
+export const VALIDATOR_KEY_SIZE: u32 =
+  ED25519_KEY_SIZE + BANDERSNATCH_KEY_SIZE + BLS_KEY_SIZE + VALIDATOR_METADATA_SIZE;
 
 /**
  * Validator key: Ed25519(32) + Bandersnatch(32) + BLS(144) + metadata(128) = 336 bytes.

--- a/sdk/test/test-ecalli/index.ts
+++ b/sdk/test/test-ecalli/index.ts
@@ -17,7 +17,10 @@ export { TestInfo } from "./info";
 export { TestLookup } from "./lookup";
 export { TestPreimages } from "./preimages";
 export { TestMachine } from "./machines";
+export { TestPrivileged } from "./privileged";
+export { TestServices } from "./services";
 export { TestStorage } from "./storage";
+export { TestTransfer } from "./transfer";
 
 // @ts-expect-error: decorator
 @external("ecalli", "resetAll")

--- a/sdk/test/test-ecalli/privileged.ts
+++ b/sdk/test/test-ecalli/privileged.ts
@@ -10,6 +10,30 @@ declare function _setAssignResult(result: i64): void;
 @external("ecalli", "setDesignateResult")
 declare function _setDesignateResult(result: i64): void;
 
+// @ts-expect-error: decorator
+@external("ecalli", "getLastBlessManager")
+declare function _getLastBlessManager(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastBlessAssignersPtr")
+declare function _getLastBlessAssignersPtr(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastBlessDelegator")
+declare function _getLastBlessDelegator(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastBlessRegistrar")
+declare function _getLastBlessRegistrar(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastBlessAutoAccumPtr")
+declare function _getLastBlessAutoAccumPtr(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastBlessAutoAccumCount")
+declare function _getLastBlessAutoAccumCount(): u32;
+
 /** Configure privileged governance mock stubs from AS test code. */
 export class TestPrivileged {
   private constructor() {}
@@ -24,5 +48,29 @@ export class TestPrivileged {
 
   static setDesignateResult(result: i64): void {
     _setDesignateResult(result);
+  }
+
+  static getLastBlessManager(): u32 {
+    return _getLastBlessManager();
+  }
+
+  static getLastBlessAssignersPtr(): u32 {
+    return _getLastBlessAssignersPtr();
+  }
+
+  static getLastBlessDelegator(): u32 {
+    return _getLastBlessDelegator();
+  }
+
+  static getLastBlessRegistrar(): u32 {
+    return _getLastBlessRegistrar();
+  }
+
+  static getLastBlessAutoAccumPtr(): u32 {
+    return _getLastBlessAutoAccumPtr();
+  }
+
+  static getLastBlessAutoAccumCount(): u32 {
+    return _getLastBlessAutoAccumCount();
   }
 }

--- a/sdk/test/test-ecalli/privileged.ts
+++ b/sdk/test/test-ecalli/privileged.ts
@@ -1,0 +1,26 @@
+// @ts-expect-error: decorator
+@external("ecalli", "setBlessResult")
+declare function _setBlessResult(result: i64): void;
+
+// @ts-expect-error: decorator
+@external("ecalli", "setAssignResult")
+declare function _setAssignResult(result: i64): void;
+
+// @ts-expect-error: decorator
+@external("ecalli", "setDesignateResult")
+declare function _setDesignateResult(result: i64): void;
+
+/** Configure privileged governance mock stubs from AS test code. */
+export class TestPrivileged {
+  static setBlessResult(result: i64): void {
+    _setBlessResult(result);
+  }
+
+  static setAssignResult(result: i64): void {
+    _setAssignResult(result);
+  }
+
+  static setDesignateResult(result: i64): void {
+    _setDesignateResult(result);
+  }
+}

--- a/sdk/test/test-ecalli/privileged.ts
+++ b/sdk/test/test-ecalli/privileged.ts
@@ -34,6 +34,22 @@ declare function _getLastBlessAutoAccumPtr(): u32;
 @external("ecalli", "getLastBlessAutoAccumCount")
 declare function _getLastBlessAutoAccumCount(): u32;
 
+// @ts-expect-error: decorator
+@external("ecalli", "getLastAssignCore")
+declare function _getLastAssignCore(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastAssignAuthQueuePtr")
+declare function _getLastAssignAuthQueuePtr(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastAssignNewAssigner")
+declare function _getLastAssignNewAssigner(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastDesignateValidatorsPtr")
+declare function _getLastDesignateValidatorsPtr(): u32;
+
 /** Configure privileged governance mock stubs from AS test code. */
 export class TestPrivileged {
   private constructor() {}
@@ -72,5 +88,21 @@ export class TestPrivileged {
 
   static getLastBlessAutoAccumCount(): u32 {
     return _getLastBlessAutoAccumCount();
+  }
+
+  static getLastAssignCore(): u32 {
+    return _getLastAssignCore();
+  }
+
+  static getLastAssignAuthQueuePtr(): u32 {
+    return _getLastAssignAuthQueuePtr();
+  }
+
+  static getLastAssignNewAssigner(): u32 {
+    return _getLastAssignNewAssigner();
+  }
+
+  static getLastDesignateValidatorsPtr(): u32 {
+    return _getLastDesignateValidatorsPtr();
   }
 }

--- a/sdk/test/test-ecalli/privileged.ts
+++ b/sdk/test/test-ecalli/privileged.ts
@@ -12,6 +12,8 @@ declare function _setDesignateResult(result: i64): void;
 
 /** Configure privileged governance mock stubs from AS test code. */
 export class TestPrivileged {
+  private constructor() {}
+
   static setBlessResult(result: i64): void {
     _setBlessResult(result);
   }

--- a/sdk/test/test-ecalli/services.ts
+++ b/sdk/test/test-ecalli/services.ts
@@ -6,13 +6,42 @@ declare function _setNewServiceResult(result: i64): void;
 @external("ecalli", "setEjectResult")
 declare function _setEjectResult(result: i64): void;
 
+// @ts-expect-error: decorator
+@external("ecalli", "getLastUpgradeCodeHashPtr")
+declare function _getLastUpgradeCodeHashPtr(): u32;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastUpgradeGas")
+declare function _getLastUpgradeGas(): i64;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getLastUpgradeAllowance")
+declare function _getLastUpgradeAllowance(): i64;
+
 /** Configure service lifecycle mock stubs from AS test code. */
 export class TestServices {
+  private constructor() {}
+
   static setNewServiceResult(result: i64): void {
     _setNewServiceResult(result);
   }
 
   static setEjectResult(result: i64): void {
     _setEjectResult(result);
+  }
+
+  /** Get the code hash pointer passed to the last upgrade() call. */
+  static getLastUpgradeCodeHashPtr(): u32 {
+    return _getLastUpgradeCodeHashPtr();
+  }
+
+  /** Get the gas passed to the last upgrade() call. */
+  static getLastUpgradeGas(): i64 {
+    return _getLastUpgradeGas();
+  }
+
+  /** Get the allowance passed to the last upgrade() call. */
+  static getLastUpgradeAllowance(): i64 {
+    return _getLastUpgradeAllowance();
   }
 }

--- a/sdk/test/test-ecalli/services.ts
+++ b/sdk/test/test-ecalli/services.ts
@@ -1,0 +1,18 @@
+// @ts-expect-error: decorator
+@external("ecalli", "setNewServiceResult")
+declare function _setNewServiceResult(result: i64): void;
+
+// @ts-expect-error: decorator
+@external("ecalli", "setEjectResult")
+declare function _setEjectResult(result: i64): void;
+
+/** Configure service lifecycle mock stubs from AS test code. */
+export class TestServices {
+  static setNewServiceResult(result: i64): void {
+    _setNewServiceResult(result);
+  }
+
+  static setEjectResult(result: i64): void {
+    _setEjectResult(result);
+  }
+}

--- a/sdk/test/test-ecalli/transfer.ts
+++ b/sdk/test/test-ecalli/transfer.ts
@@ -1,0 +1,10 @@
+// @ts-expect-error: decorator
+@external("ecalli", "setTransferResult")
+declare function _setTransferResult(result: i64): void;
+
+/** Configure transfer mock stub from AS test code. */
+export class TestTransfer {
+  static setTransferResult(result: i64): void {
+    _setTransferResult(result);
+  }
+}

--- a/sdk/test/test-ecalli/transfer.ts
+++ b/sdk/test/test-ecalli/transfer.ts
@@ -4,6 +4,8 @@ declare function _setTransferResult(result: i64): void;
 
 /** Configure transfer mock stub from AS test code. */
 export class TestTransfer {
+  private constructor() {}
+
   static setTransferResult(result: i64): void {
     _setTransferResult(result);
   }

--- a/sdk/test/test-run.ts
+++ b/sdk/test/test-run.ts
@@ -4,7 +4,11 @@ import * as decode from "../core/codec/decode.test";
 import * as encode from "../core/codec/encode.test";
 import * as roundtrip from "../core/codec/index.test";
 import * as accountInfo from "../jam/account-info.test";
+import * as admin from "../jam/accumulate/admin.test";
+import * as childServices from "../jam/accumulate/child-services.test";
 import * as accumulateItem from "../jam/accumulate/item.test";
+import * as selfService from "../jam/accumulate/self-service.test";
+import * as transferTest from "../jam/accumulate/transfer.test";
 import * as context from "../jam/context.test";
 import * as machine from "../jam/machine.test";
 import * as preimages from "../jam/preimages.test";
@@ -22,10 +26,14 @@ export function runAllTests(): void {
     TestSuite.create(roundtrip.TESTS, "roundtrip.ts"),
     TestSuite.create(accountInfo.TESTS, "account-info.ts"),
     TestSuite.create(accumulateItem.TESTS, "accumulate-item.ts"),
+    TestSuite.create(admin.TESTS, "admin.ts"),
+    TestSuite.create(childServices.TESTS, "child-services.ts"),
     TestSuite.create(context.TESTS, "context.ts"),
     TestSuite.create(machine.TESTS, "machine.ts"),
     TestSuite.create(preimages.TESTS, "preimages.ts"),
+    TestSuite.create(selfService.TESTS, "self-service.ts"),
     TestSuite.create(service.TESTS, "service.ts"),
+    TestSuite.create(transferTest.TESTS, "transfer.ts"),
     TestSuite.create(workPackage.TESTS, "work-package.ts"),
   ]);
 }


### PR DESCRIPTION
## Summary

- **Admin** class wrapping privileged governance ecallis: `bless` (full + partial for delegator/registrar), `assign`, `designate`
- **ChildServices** class: `newChild` (ecalli 18), `ejectChild` (ecalli 21)
- **SelfService** class: `upgradeCode`, `requestEjection` (both via ecalli 19)
- **Memo** class: fixed 128-byte transfer memo with auto-pad/truncate
- **`AccumulateContext.scheduleTransfer`** method (ecalli 20) with `TransferError` enum
- New types: `ValidatorKey`, `AutoAccumulateEntry` in `sdk/jam/types.ts`
- Configurable mock stubs + AS test helpers for all new ecallis
- Fixed ecalli docs: `bless.ts` (assigners, not auth_queue), `assign.ts` (newAssigner, not bitmask)
- 35 new tests (180 total SDK tests), all passing

## Test plan

- [x] `npm test` — 180/180 SDK tests, all example tests pass
- [x] `npm run build` — full build including wasm-pvm compile
- [x] `npx biome ci` — lint and formatting clean
- [ ] Manual review of Admin.bless encoding (assigners as flat ServiceId array, autoAccumulate as ServiceId+Gas pairs with count in r12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)