### PR TITLE
Add deeper verification tests for ecallis 6-26

### DIFF
--- a/examples/ecalli-test/assembly/accumulate.test.ts
+++ b/examples/ecalli-test/assembly/accumulate.test.ts
@@ -1,5 +1,15 @@
 import { AccumulateContext, BytesBlob, Decoder, Encoder } from "@fluffylabs/as-lan";
-import { Assert, Test, TestAccumulate, test } from "@fluffylabs/as-lan/test";
+import {
+  Assert,
+  Test,
+  TestAccumulate,
+  TestEcalli,
+  TestPreimages,
+  TestPrivileged,
+  TestServices,
+  TestTransfer,
+  test,
+} from "@fluffylabs/as-lan/test";
 import { EcalliIndex } from "./ecalli-index";
 import { buildTransferItem, callAccumulate, callAccumulateWithOperand } from "./test-helpers";
 
@@ -191,6 +201,135 @@ export const TESTS: Test[] = [
     const resp = callAccumulateWithOperand(p.finishRaw());
     const assert = Assert.create();
     assert.isEqual(resp.result, 0, "provide returns OK");
+    return assert;
+  }),
+
+  // === Deeper verification tests ===
+
+  test("query: r8 carries configured slot info", () => {
+    // r7=100 (preimage length), r8=7 (slot1=7, slot2=0)
+    TestPreimages.setQueryResult(100, 7);
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Query);
+    p.bytesFixLen(BytesBlob.zero(32));
+    p.varU64(64);
+
+    const resp = callAccumulateWithOperand(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, 100, "query returns preimage length");
+    assert.isEqual(resp.data.raw.length, 8, "r8 output length");
+    // r8=7 in little-endian: 0x07 0x00 ...
+    assert.isEqual(resp.data.raw[0], 7, "r8 byte 0 (slot1)");
+    assert.isEqual(resp.data.raw[1], 0, "r8 byte 1");
+    return assert;
+  }),
+
+  test("new_service: incrementing service IDs", () => {
+    TestEcalli.reset();
+    const p1 = Encoder.create();
+    p1.varU64(EcalliIndex.NewService);
+    p1.bytesFixLen(BytesBlob.zero(32));
+    p1.varU64(1024);
+    p1.varU64(100000);
+    p1.varU64(50000);
+    p1.varU64(0);
+    p1.varU64(u64(u32.MAX_VALUE));
+    const resp1 = callAccumulateWithOperand(p1.finishRaw());
+
+    const p2 = Encoder.create();
+    p2.varU64(EcalliIndex.NewService);
+    p2.bytesFixLen(BytesBlob.zero(32));
+    p2.varU64(1024);
+    p2.varU64(100000);
+    p2.varU64(50000);
+    p2.varU64(0);
+    p2.varU64(u64(u32.MAX_VALUE));
+    const resp2 = callAccumulateWithOperand(p2.finishRaw());
+
+    const assert = Assert.create();
+    assert.isEqual(resp1.result, 256, "first new_service returns ID 256");
+    assert.isEqual(resp2.result, 257, "second new_service returns ID 257");
+    return assert;
+  }),
+
+  test("bless: captures scalar arguments", () => {
+    TestEcalli.reset();
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Bless);
+    p.varU64(10); // manager
+    p.bytesVarLen(BytesBlob.empty()); // auth_queue
+    p.varU64(20); // delegator
+    p.varU64(30); // registrar
+    p.bytesVarLen(BytesBlob.empty()); // auto_accum
+    p.varU64(5); // auto_accum_count
+
+    const resp = callAccumulateWithOperand(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, 0, "bless returns OK");
+    assert.isEqual(TestPrivileged.getLastBlessManager(), 10, "manager");
+    assert.isEqual(TestPrivileged.getLastBlessDelegator(), 20, "delegator");
+    assert.isEqual(TestPrivileged.getLastBlessRegistrar(), 30, "registrar");
+    assert.isEqual(TestPrivileged.getLastBlessAutoAccumCount(), 5, "auto_accum_count");
+    return assert;
+  }),
+
+  test("assign: captures scalar arguments", () => {
+    TestEcalli.reset();
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Assign);
+    p.varU64(7); // core
+    p.bytesVarLen(BytesBlob.empty()); // auth_queue
+    p.varU64(42); // new_assigner
+
+    const resp = callAccumulateWithOperand(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, 0, "assign returns OK");
+    assert.isEqual(TestPrivileged.getLastAssignCore(), 7, "core");
+    assert.isEqual(TestPrivileged.getLastAssignNewAssigner(), 42, "new_assigner");
+    return assert;
+  }),
+
+  test("upgrade: captures arguments", () => {
+    TestEcalli.reset();
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Upgrade);
+    p.bytesFixLen(BytesBlob.zero(32)); // code_hash
+    p.varU64(200000); // gas
+    p.varU64(100000); // allowance
+
+    const resp = callAccumulateWithOperand(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, 0, "upgrade returns OK");
+    assert.isEqual(TestServices.getLastUpgradeGas(), 200000, "gas");
+    assert.isEqual(TestServices.getLastUpgradeAllowance(), 100000, "allowance");
+    return assert;
+  }),
+
+  test("solicit: returns HUH when configured", () => {
+    TestPreimages.setSolicitResult(-9);
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Solicit);
+    p.bytesFixLen(BytesBlob.zero(32));
+    p.varU64(64);
+
+    const resp = callAccumulateWithOperand(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -9, "solicit returns HUH");
+    return assert;
+  }),
+
+  test("transfer ecalli: returns LOW when configured", () => {
+    TestTransfer.setTransferResult(-1);
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Transfer);
+    p.varU64(100);
+    p.varU64(500);
+    p.varU64(1000);
+    p.bytesVarLen(BytesBlob.zero(128));
+
+    const resp = callAccumulateWithOperand(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -1, "transfer returns LOW");
     return assert;
   }),
 ];

--- a/examples/ecalli-test/assembly/refine.test.ts
+++ b/examples/ecalli-test/assembly/refine.test.ts
@@ -1,5 +1,14 @@
 import { BytesBlob, Encoder } from "@fluffylabs/as-lan";
-import { Assert, Test, TestStorage, test } from "@fluffylabs/as-lan/test";
+import {
+  Assert,
+  Test,
+  TestEcalli,
+  TestExportSegment,
+  TestHistoricalLookup,
+  TestMachine,
+  TestStorage,
+  test,
+} from "@fluffylabs/as-lan/test";
 import { EcalliIndex } from "./ecalli-index";
 import { callRefine, strBlob } from "./test-helpers";
 
@@ -255,6 +264,157 @@ export const TESTS: Test[] = [
     const resp = callRefine(p.finishRaw());
     const assert = Assert.create();
     assert.isEqual(resp.result, 0, "expunge returns OK");
+    return assert;
+  }),
+
+  // === Deeper verification tests ===
+
+  test("export: incrementing segment IDs", () => {
+    TestEcalli.reset();
+    const p1 = Encoder.create();
+    p1.varU64(EcalliIndex.Export);
+    p1.bytesVarLen(BytesBlob.zero(8));
+    const resp1 = callRefine(p1.finishRaw());
+
+    const p2 = Encoder.create();
+    p2.varU64(EcalliIndex.Export);
+    p2.bytesVarLen(BytesBlob.zero(8));
+    const resp2 = callRefine(p2.finishRaw());
+
+    const assert = Assert.create();
+    assert.isEqual(resp1.result, 0, "first export returns index 0");
+    assert.isEqual(resp2.result, 1, "second export returns index 1");
+    return assert;
+  }),
+
+  test("export: returns FULL when overridden", () => {
+    TestExportSegment.setResult(-5);
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Export);
+    p.bytesVarLen(BytesBlob.zero(8));
+    const resp = callRefine(p.finishRaw());
+
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -5, "export returns FULL");
+    return assert;
+  }),
+
+  test("machine: incrementing machine IDs", () => {
+    TestEcalli.reset();
+    const p1 = Encoder.create();
+    p1.varU64(EcalliIndex.Machine);
+    p1.bytesVarLen(BytesBlob.zero(4));
+    p1.varU64(0);
+    const resp1 = callRefine(p1.finishRaw());
+
+    const p2 = Encoder.create();
+    p2.varU64(EcalliIndex.Machine);
+    p2.bytesVarLen(BytesBlob.zero(4));
+    p2.varU64(0);
+    const resp2 = callRefine(p2.finishRaw());
+
+    const assert = Assert.create();
+    assert.isEqual(resp1.result, 0, "first machine returns ID 0");
+    assert.isEqual(resp2.result, 1, "second machine returns ID 1");
+    return assert;
+  }),
+
+  test("machine: returns HUH when overridden", () => {
+    TestMachine.setMachineResult(-9);
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Machine);
+    p.bytesVarLen(BytesBlob.zero(4));
+    p.varU64(0);
+    const resp = callRefine(p.finishRaw());
+
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -9, "machine returns HUH");
+    return assert;
+  }),
+
+  test("invoke: r8 carries configured value", () => {
+    TestMachine.setInvokeResult(0, 42); // HALT, r8=42
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Invoke);
+    p.varU64(0);
+    p.bytesVarLen(BytesBlob.zero(8));
+
+    const resp = callRefine(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, 0, "invoke returns HALT");
+    assert.isEqual(resp.data.raw.length, 8, "r8 output length");
+    // r8=42 in little-endian: 0x2A 0x00 ...
+    assert.isEqual(resp.data.raw[0], 0x2a, "r8 byte 0");
+    assert.isEqual(resp.data.raw[1], 0x00, "r8 byte 1");
+    return assert;
+  }),
+
+  test("invoke: returns WHO for unknown machine", () => {
+    TestMachine.setInvokeResult(-4, 0); // WHO
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Invoke);
+    p.varU64(99);
+    p.bytesVarLen(BytesBlob.zero(8));
+
+    const resp = callRefine(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -4, "invoke returns WHO");
+    return assert;
+  }),
+
+  test("historical_lookup: returns NONE when configured", () => {
+    TestHistoricalLookup.setNone();
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.HistoricalLookup);
+    p.varU64(u64(u32.MAX_VALUE));
+    p.bytesFixLen(BytesBlob.zero(32));
+    p.varU64(0);
+    p.varU64(256);
+
+    const resp = callRefine(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -1, "historical_lookup returns NONE");
+    assert.isEqual(resp.data.raw.length, 0, "no data");
+    return assert;
+  }),
+
+  test("historical_lookup: returns custom preimage data", () => {
+    const preimage = new Uint8Array(5);
+    preimage[0] = 0xab;
+    preimage[1] = 0xcd;
+    preimage[2] = 0xef;
+    preimage[3] = 0x01;
+    preimage[4] = 0x23;
+    TestHistoricalLookup.setPreimage(preimage);
+
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.HistoricalLookup);
+    p.varU64(u64(u32.MAX_VALUE));
+    p.bytesFixLen(BytesBlob.zero(32));
+    p.varU64(0);
+    p.varU64(256);
+
+    const resp = callRefine(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, 5, "custom preimage length");
+    assert.isEqual(resp.data.raw.length, 5, "data length");
+    assert.isEqual(resp.data.raw[0], 0xab, "data[0]");
+    assert.isEqual(resp.data.raw[1], 0xcd, "data[1]");
+    assert.isEqual(resp.data.raw[4], 0x23, "data[4]");
+    return assert;
+  }),
+
+  test("peek: returns WHO for unknown machine", () => {
+    TestMachine.setPeekResult(-4);
+    const p = Encoder.create();
+    p.varU64(EcalliIndex.Peek);
+    p.varU64(99);
+    p.varU64(0);
+    p.varU64(8);
+
+    const resp = callRefine(p.finishRaw());
+    const assert = Assert.create();
+    assert.isEqual(resp.result, -4, "peek returns WHO");
     return assert;
   }),
 ];


### PR DESCRIPTION
## Summary
- Adds 16 new tests (9 refine, 7 accumulate) that deeply verify ecalli host calls 6-26
- Covers all priority items from #59: counter-based incrementing (export, machine, new_service), dual-register r8 content (invoke, query), argument capture (bless, assign, upgrade), configurable mock states (historical_lookup), and error cases (WHO, HUH, FULL, LOW)
- Total ecalli-test count: 38 → 54

## Test plan
- [x] All 54 ecalli-test tests pass
- [x] Full suite green (201 + 3 + 3 + 54 + 5)
- [x] Biome lint clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)