### PR TITLE
feat(library): add Library example service with preimage-backed PVM libraries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,20 @@ examples/
       accumulate.test.ts    Tests for accumulate ecallis via operand/transfer flow (14 tests)
       authorize.test.ts     Tests for general ecallis via authorize dispatch (7 tests)
       test-helpers.ts       Shared test utilities (callRefine, callAccumulate, builders)
+  library/                  Library service — hosts reusable PVM verification blobs
+                            (ed25519, blake2b, …) as preimages, resolved by name via
+                            storage. Refine demo invokes them via the Machine interface.
+    fixtures/
+      halt.pvm              Placeholder preimage bytes (real code lands later)
+    assembly/
+      index.ts              Exports refine + accumulate
+      refine.ts             Tag dispatch (0=demo, 1=admin) + inner-PVM lifecycle
+      accumulate.ts         Operand loop + admin command dispatch
+      admin.ts              AdminCommand tagged union + codec (Set/Remove/Solicit/Forget/Provide)
+      storage.ts            LibraryEntry + codec + "lib:<name>" key helper
+      test-helpers.ts       Shared test utilities (callRefine, callAccumulate, builders)
+      refine.test.ts
+      accumulate.test.ts
 docs/                       Documentation (mdbook)
 ```
 

--- a/docs/src/sdk-api/common.md
+++ b/docs/src/sdk-api/common.md
@@ -20,7 +20,7 @@ High-level wrappers for service storage (`read`/`write`) and account info (`info
 const storage = ctx.serviceData();
 const info = storage.info();                  // Optional<AccountInfo>
 const val = storage.read(key);               // Optional<Uint8Array>
-const result = storage.write(key, value);    // Result<OptionalN<u64>, WriteError>
+const result = storage.write(key, value);    // value: BytesBlob → Result<OptionalN<u64>, WriteError>
 
 // Read-only access to another service by ID
 const other = ServiceData.create(42);

--- a/docs/src/sdk-api/refine.md
+++ b/docs/src/sdk-api/refine.md
@@ -128,3 +128,35 @@ Typed wrapper for the 112-byte gas+registers I/O structure:
 ### PageAccess
 
 `Inaccessible` (0), `Read` (1), `ReadWrite` (2).
+
+### Calling convention for library-style inner PVMs
+
+The `Machine` API is general — you can set up any memory layout and register
+state you like. For the common case of invoking a *library* PVM (an inner
+blob that takes some input, returns some output, and halts), `examples/library/`
+uses a fixed convention mirroring the outer JAM service ABI:
+
+**On entry (before `invoke`):**
+
+- Caller maps a RW page region at `INPUT_ADDR = 0xFEFF0000` via
+  `machine.pages(startPage, pageCount, PageAccess.ReadWrite)` sized to fit
+  the payload (`pageCount = ceil(payload.length / 4096)`).
+- Caller copies the payload into inner memory with `machine.poke(INPUT_ADDR, payload)`.
+- Caller sets `io.setRegister(7, INPUT_ADDR)` and `io.setRegister(8, payload.length)`
+  — the same `(ptr, len)` convention every JAM service entry point receives.
+
+**On halt:**
+
+- Inner PVM places its output anywhere in its memory and returns a packed
+  `ptrAndLen` in `r7` — low 32 bits = address, high 32 bits = length, matching
+  the SDK's `ptrAndLen(Uint8Array)` helper.
+- Caller unpacks `r7`, calls `machine.peek(outAddr, buf)` for `outLen` bytes,
+  then `machine.expunge()`.
+
+**Why this matters:** writing a library PVM to a different convention means
+consumers have to special-case your library. Following this convention lets
+authors of ed25519, blake2b, and similar verification primitives all be
+invoked identically.
+
+See `examples/library/assembly/refine.ts` for the full reference
+implementation (error handling, page sizing, peek unwind on failure).

--- a/examples/library/asconfig.json
+++ b/examples/library/asconfig.json
@@ -1,0 +1,30 @@
+{
+  "entries": ["assembly/index.ts"],
+  "targets": {
+    "debug": {
+      "outFile": "build/debug.wasm",
+      "textFile": "build/debug.wat",
+      "sourceMap": true,
+      "debug": true
+    },
+    "release": {
+      "outFile": "build/release.wasm",
+      "textFile": "build/release.wat",
+      "sourceMap": true,
+      "optimizeLevel": 3,
+      "shrinkLevel": 2,
+      "converge": true,
+      "noAssert": true
+    },
+    "test": {
+      "outFile": "build/test.wasm",
+      "textFile": "build/test.wat",
+      "sourceMap": true,
+      "debug": true
+    }
+  },
+  "options": {
+    "bindings": "esm",
+    "maximumMemory": 16
+  }
+}

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -31,6 +31,57 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("accumulate: RemoveMapping deletes storage entry", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0x11;
+    const entryEnc = Encoder.create();
+    LibraryEntryCodec.create().encode(LibraryEntry.create(hash, 32), entryEnc);
+    TestStorage.set(BytesBlob.wrap(libraryKey("blake2b")), BytesBlob.wrap(entryEnc.finishRaw()));
+
+    const cmd = AdminCommand.removeMapping(BytesBlob.encodeAscii("blake2b"));
+    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(cmd)));
+    callAccumulate(1);
+
+    const got = CurrentServiceData.create().read(libraryKey("blake2b"));
+    assert.isEqual(got.isSome, false, "entry removed");
+    return assert;
+  }),
+
+  test("accumulate: Solicit calls solicit ecalli", () => {
+    const assert = Assert.create();
+    TestPreimages.resetCounters();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0x22;
+    const cmd = AdminCommand.solicit(hash, 1024);
+    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(cmd)));
+    callAccumulate(1);
+    assert.isEqual(TestPreimages.getSolicitCount(), 1, "solicit count");
+    return assert;
+  }),
+
+  test("accumulate: Forget calls forget ecalli", () => {
+    const assert = Assert.create();
+    TestPreimages.resetCounters();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0x33;
+    const cmd = AdminCommand.forget(hash, 512);
+    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(cmd)));
+    callAccumulate(1);
+    assert.isEqual(TestPreimages.getForgetCount(), 1, "forget count");
+    return assert;
+  }),
+
+  test("accumulate: Provide calls provide ecalli", () => {
+    const assert = Assert.create();
+    TestPreimages.resetCounters();
+    const cmd = AdminCommand.provide(BytesBlob.parseBlob("0xdeadbeef").okay!);
+    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(cmd)));
+    callAccumulate(1);
+    assert.isEqual(TestPreimages.getProvideCount(), 1, "provide count");
+    return assert;
+  }),
+
   test("accumulate: SetMapping writes LibraryEntry to storage", () => {
     const assert = Assert.create();
     TestStorage.set(BytesBlob.wrap(libraryKey("ed25519")), null);

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -1,11 +1,4 @@
-import {
-  AccumulateContext,
-  Bytes32,
-  BytesBlob,
-  CurrentServiceData,
-  Decoder,
-  Encoder,
-} from "@fluffylabs/as-lan";
+import { AccumulateContext, Bytes32, BytesBlob, CurrentServiceData, Decoder, Encoder } from "@fluffylabs/as-lan";
 import { Assert, Test, TestAccumulate, TestPreimages, TestStorage, test } from "@fluffylabs/as-lan/test";
 import { AdminCommand, AdminCommandCodec } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -1,5 +1,21 @@
-import { AccumulateContext, Bytes32 } from "@fluffylabs/as-lan";
-import { Assert, Test, TestPreimages, test } from "@fluffylabs/as-lan/test";
+import {
+  AccumulateContext,
+  Bytes32,
+  BytesBlob,
+  CurrentServiceData,
+  Decoder,
+  Encoder,
+} from "@fluffylabs/as-lan";
+import { Assert, Test, TestAccumulate, TestPreimages, TestStorage, test } from "@fluffylabs/as-lan/test";
+import { AdminCommand, AdminCommandCodec } from "./admin";
+import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";
+import { buildAdminOperand, callAccumulate } from "./test-helpers";
+
+function encodeAdmin(cmd: AdminCommand): Uint8Array {
+  const enc = Encoder.create();
+  AdminCommandCodec.create().encode(cmd, enc);
+  return enc.finishRaw();
+}
 
 export const TESTS: Test[] = [
   test("mock: solicit counter increments on call", () => {
@@ -12,6 +28,28 @@ export const TESTS: Test[] = [
     assert.isEqual(TestPreimages.getSolicitCount(), 1, "solicit count");
     assert.isEqual(TestPreimages.getForgetCount(), 0, "forget count");
     assert.isEqual(TestPreimages.getProvideCount(), 0, "provide count");
+    return assert;
+  }),
+
+  test("accumulate: SetMapping writes LibraryEntry to storage", () => {
+    const assert = Assert.create();
+    TestStorage.set(BytesBlob.wrap(libraryKey("ed25519")), null);
+
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0xab;
+    const cmd = AdminCommand.setMapping(BytesBlob.encodeAscii("ed25519"), hash, 8192);
+    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(cmd)));
+    callAccumulate(1);
+
+    const sd = CurrentServiceData.create();
+    const got = sd.read(libraryKey("ed25519"));
+    if (!got.isSome) {
+      assert.fail("entry not written");
+      return assert;
+    }
+    const decoded = LibraryEntryCodec.create().decode(Decoder.fromBlob(got.val!)).okay!;
+    assert.isEqual(decoded.hash.raw[0], 0xab, "hash");
+    assert.isEqual(decoded.length, 8192, "length");
     return assert;
   }),
 ];

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -82,6 +82,32 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("accumulate: malformed operand bytes are skipped silently", () => {
+    const assert = Assert.create();
+    TestPreimages.resetCounters();
+    TestAccumulate.setItem(0, buildAdminOperand(BytesBlob.parseBlob("0x99ff").okay!.raw));
+    const hash = Bytes32.zero();
+    const good = encodeAdmin(AdminCommand.solicit(hash, 1));
+    TestAccumulate.setItem(1, buildAdminOperand(good));
+    callAccumulate(2);
+    assert.isEqual(TestPreimages.getSolicitCount(), 1, "good operand still dispatched");
+    return assert;
+  }),
+
+  test("accumulate: multiple operands processed in order", () => {
+    const assert = Assert.create();
+    TestPreimages.resetCounters();
+    const h1 = Bytes32.zero();
+    h1.raw[0] = 0xaa;
+    const h2 = Bytes32.zero();
+    h2.raw[0] = 0xbb;
+    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(AdminCommand.solicit(h1, 1))));
+    TestAccumulate.setItem(1, buildAdminOperand(encodeAdmin(AdminCommand.solicit(h2, 2))));
+    callAccumulate(2);
+    assert.isEqual(TestPreimages.getSolicitCount(), 2, "both dispatched");
+    return assert;
+  }),
+
   test("accumulate: SetMapping writes LibraryEntry to storage", () => {
     const assert = Assert.create();
     TestStorage.set(BytesBlob.wrap(libraryKey("ed25519")), null);

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -87,17 +87,25 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
-  test("accumulate: multiple operands processed in order", () => {
+  test("accumulate: operands dispatched in index order", () => {
     const assert = Assert.create();
-    TestPreimages.resetCounters();
-    const h1 = Bytes32.zero();
-    h1.raw[0] = 0xaa;
-    const h2 = Bytes32.zero();
-    h2.raw[0] = 0xbb;
-    TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(AdminCommand.solicit(h1, 1))));
-    TestAccumulate.setItem(1, buildAdminOperand(encodeAdmin(AdminCommand.solicit(h2, 2))));
+    // Set then Remove → storage ends empty. Reversed order would leave the
+    // entry present. Observable side-effect therefore depends on ordering.
+    TestStorage.set(BytesBlob.wrap(libraryKey("ordered")), null);
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0x55;
+    TestAccumulate.setItem(
+      0,
+      buildAdminOperand(encodeAdmin(AdminCommand.setMapping(BytesBlob.encodeAscii("ordered"), hash, 16))),
+    );
+    TestAccumulate.setItem(
+      1,
+      buildAdminOperand(encodeAdmin(AdminCommand.removeMapping(BytesBlob.encodeAscii("ordered")))),
+    );
     callAccumulate(2);
-    assert.isEqual(TestPreimages.getSolicitCount(), 2, "both dispatched");
+
+    const got = CurrentServiceData.create().read(libraryKey("ordered"));
+    assert.isEqual(got.isSome, false, "Remove ran after Set");
     return assert;
   }),
 

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -1,0 +1,17 @@
+import { AccumulateContext, Bytes32 } from "@fluffylabs/as-lan";
+import { Assert, Test, TestPreimages, test } from "@fluffylabs/as-lan/test";
+
+export const TESTS: Test[] = [
+  test("mock: solicit counter increments on call", () => {
+    const assert = Assert.create();
+    TestPreimages.resetCounters();
+
+    const ctx = AccumulateContext.create();
+    ctx.preimages().solicit(Bytes32.zero(), 64);
+
+    assert.isEqual(TestPreimages.getSolicitCount(), 1, "solicit count");
+    assert.isEqual(TestPreimages.getForgetCount(), 0, "forget count");
+    assert.isEqual(TestPreimages.getProvideCount(), 0, "provide count");
+    return assert;
+  }),
+];

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -1,6 +1,41 @@
-import { AccumulateContext, Bytes32 } from "@fluffylabs/as-lan";
+import {
+  AccumulateContext,
+  Bytes32,
+  Decoder,
+  Encoder,
+  WorkExecResultKind,
+} from "@fluffylabs/as-lan";
+import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
+import { LibraryEntry, LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
-export function accumulate(_ptr: u32, _len: u32): u64 {
+export function accumulate(ptr: u32, len: u32): u64 {
   const ctx = AccumulateContext.create();
+  const args = ctx.parseArgs(ptr, len);
+  const fetcher = ctx.fetcher();
+  const adminCodec = AdminCommandCodec.create();
+
+  for (let i: u32 = 0; i < args.argsLength; i++) {
+    const itemOpt = fetcher.oneTransferOrOperand(i);
+    if (!itemOpt.isSome) continue;
+    const item = itemOpt.val!;
+    if (!item.isOperand) continue;
+    const op = item.operand;
+    if (op.result.kind !== WorkExecResultKind.Ok) continue;
+    const body = op.result.okBlob;
+
+    const r = adminCodec.decode(Decoder.fromBlob(body.raw));
+    if (r.isError) continue; // defensive — refine already validates
+
+    dispatch(ctx, r.okay!);
+  }
+
   return ctx.yieldHash(Bytes32.zero());
+}
+
+function dispatch(ctx: AccumulateContext, cmd: AdminCommand): void {
+  if (cmd.kind === AdminCommandKind.SetMapping) {
+    const entryEnc = Encoder.create();
+    LibraryEntryCodec.create().encode(LibraryEntry.create(cmd.hash!, cmd.length), entryEnc);
+    ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), entryEnc.finishRaw());
+  }
 }

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -37,5 +37,13 @@ function dispatch(ctx: AccumulateContext, cmd: AdminCommand): void {
     const entryEnc = Encoder.create();
     LibraryEntryCodec.create().encode(LibraryEntry.create(cmd.hash!, cmd.length), entryEnc);
     ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), entryEnc.finishRaw());
+  } else if (cmd.kind === AdminCommandKind.RemoveMapping) {
+    ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), new Uint8Array(0));
+  } else if (cmd.kind === AdminCommandKind.Solicit) {
+    ctx.preimages().solicit(cmd.hash!, cmd.length);
+  } else if (cmd.kind === AdminCommandKind.Forget) {
+    ctx.preimages().forget(cmd.hash!, cmd.length);
+  } else if (cmd.kind === AdminCommandKind.Provide) {
+    ctx.preimages().provide(cmd.preimage!);
   }
 }

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -1,4 +1,4 @@
-import { AccumulateContext, Bytes32, Decoder, Encoder, WorkExecResultKind } from "@fluffylabs/as-lan";
+import { AccumulateContext, Bytes32, BytesBlob, Decoder, Encoder, WorkExecResultKind } from "@fluffylabs/as-lan";
 import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
@@ -35,9 +35,9 @@ function dispatch(ctx: AccumulateContext, cmd: AdminCommand): void {
   if (cmd.kind === AdminCommandKind.SetMapping) {
     const entryEnc = Encoder.create();
     LibraryEntryCodec.create().encode(LibraryEntry.create(cmd.hash!, cmd.length), entryEnc);
-    ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), entryEnc.finishRaw());
+    ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), entryEnc.finish());
   } else if (cmd.kind === AdminCommandKind.RemoveMapping) {
-    ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), new Uint8Array(0));
+    ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), BytesBlob.empty());
   } else if (cmd.kind === AdminCommandKind.Solicit) {
     ctx.preimages().solicit(cmd.hash!, cmd.length);
   } else if (cmd.kind === AdminCommandKind.Forget) {

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -17,8 +17,10 @@ export function accumulate(ptr: u32, len: u32): u64 {
     if (op.result.kind !== WorkExecResultKind.Ok) continue;
     const body = op.result.okBlob;
 
-    const r = adminCodec.decode(Decoder.fromBlob(body.raw));
+    const d = Decoder.fromBlob(body.raw);
+    const r = adminCodec.decode(d);
     if (r.isError) continue; // defensive — refine already validates
+    if (!d.isFinished()) continue; // reject trailing bytes (defensive)
 
     dispatch(ctx, r.okay!);
   }

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -1,0 +1,6 @@
+import { AccumulateContext, Bytes32 } from "@fluffylabs/as-lan";
+
+export function accumulate(_ptr: u32, _len: u32): u64 {
+  const ctx = AccumulateContext.create();
+  return ctx.yieldHash(Bytes32.zero());
+}

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -26,6 +26,11 @@ export function accumulate(ptr: u32, len: u32): u64 {
   return ctx.yieldHash(Bytes32.zero());
 }
 
+// Admin side-effect calls intentionally ignore their return values: in
+// accumulate there is no caller to surface errors to, and every failure mode
+// (WriteError.Full, SolicitError.Full/Huh, ForgetError.Huh, ProvideError.Huh/Who)
+// is either transient or operator-misconfiguration — both of which are better
+// diagnosed from host logs than encoded into the service response.
 function dispatch(ctx: AccumulateContext, cmd: AdminCommand): void {
   if (cmd.kind === AdminCommandKind.SetMapping) {
     const entryEnc = Encoder.create();

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -1,28 +1,54 @@
-import { AccumulateContext, Bytes32, BytesBlob, Decoder, Encoder, WorkExecResultKind } from "@fluffylabs/as-lan";
+import {
+  AccumulateContext,
+  Bytes32,
+  BytesBlob,
+  Decoder,
+  Encoder,
+  Logger,
+  WorkExecResultKind,
+} from "@fluffylabs/as-lan";
 import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
+
+const logger: Logger = Logger.create("library");
 
 export function accumulate(ptr: u32, len: u32): u64 {
   const ctx = AccumulateContext.create();
   const args = ctx.parseArgs(ptr, len);
   const fetcher = ctx.fetcher();
   const adminCodec = AdminCommandCodec.create();
+  logger.info(`accumulate: slot=${args.slot} service=${args.serviceId} argsLength=${args.argsLength}`);
 
   for (let i: u32 = 0; i < args.argsLength; i++) {
     const itemOpt = fetcher.oneTransferOrOperand(i);
-    if (!itemOpt.isSome) continue;
+    if (!itemOpt.isSome) {
+      logger.warn(`accumulate[${i}]: fetch returned none, skipping`);
+      continue;
+    }
     const item = itemOpt.val!;
-    if (!item.isOperand) continue;
+    if (!item.isOperand) {
+      logger.debug(`accumulate[${i}]: transfer item, skipping`);
+      continue;
+    }
     const op = item.operand;
-    if (op.result.kind !== WorkExecResultKind.Ok) continue;
+    if (op.result.kind !== WorkExecResultKind.Ok) {
+      logger.warn(`accumulate[${i}]: non-ok work result kind=${op.result.kind}, skipping`);
+      continue;
+    }
     const body = op.result.okBlob;
 
     const d = Decoder.fromBlob(body.raw);
     const r = adminCodec.decode(d);
-    if (r.isError) continue; // defensive — refine already validates
-    if (!d.isFinished()) continue; // reject trailing bytes (defensive)
+    if (r.isError) {
+      logger.warn(`accumulate[${i}]: malformed operand, skipping`);
+      continue;
+    }
+    if (!d.isFinished()) {
+      logger.warn(`accumulate[${i}]: trailing bytes after admin cmd, skipping`);
+      continue;
+    }
 
-    dispatch(ctx, r.okay!);
+    dispatch(ctx, i, r.okay!);
   }
 
   return ctx.yieldHash(Bytes32.zero());
@@ -33,18 +59,25 @@ export function accumulate(ptr: u32, len: u32): u64 {
 // (WriteError.Full, SolicitError.Full/Huh, ForgetError.Huh, ProvideError.Huh/Who)
 // is either transient or operator-misconfiguration — both of which are better
 // diagnosed from host logs than encoded into the service response.
-function dispatch(ctx: AccumulateContext, cmd: AdminCommand): void {
+function dispatch(ctx: AccumulateContext, i: u32, cmd: AdminCommand): void {
   if (cmd.kind === AdminCommandKind.SetMapping) {
+    logger.info(
+      `accumulate[${i}]: SetMapping name=${cmd.name!.toString()} hash=${cmd.hash!.toString()} len=${cmd.length}`,
+    );
     const entryEnc = Encoder.create();
     LibraryEntryCodec.create().encode(LibraryEntry.create(cmd.hash!, cmd.length), entryEnc);
     ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), entryEnc.finish());
   } else if (cmd.kind === AdminCommandKind.RemoveMapping) {
+    logger.info(`accumulate[${i}]: RemoveMapping name=${cmd.name!.toString()}`);
     ctx.serviceData().write(libraryKeyFromBlob(cmd.name!), BytesBlob.empty());
   } else if (cmd.kind === AdminCommandKind.Solicit) {
+    logger.info(`accumulate[${i}]: Solicit hash=${cmd.hash!.toString()} len=${cmd.length}`);
     ctx.preimages().solicit(cmd.hash!, cmd.length);
   } else if (cmd.kind === AdminCommandKind.Forget) {
+    logger.info(`accumulate[${i}]: Forget hash=${cmd.hash!.toString()} len=${cmd.length}`);
     ctx.preimages().forget(cmd.hash!, cmd.length);
   } else if (cmd.kind === AdminCommandKind.Provide) {
+    logger.info(`accumulate[${i}]: Provide preimageLen=${cmd.preimage!.length}`);
     ctx.preimages().provide(cmd.preimage!);
   }
 }

--- a/examples/library/assembly/accumulate.ts
+++ b/examples/library/assembly/accumulate.ts
@@ -1,10 +1,4 @@
-import {
-  AccumulateContext,
-  Bytes32,
-  Decoder,
-  Encoder,
-  WorkExecResultKind,
-} from "@fluffylabs/as-lan";
+import { AccumulateContext, Bytes32, Decoder, Encoder, WorkExecResultKind } from "@fluffylabs/as-lan";
 import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 

--- a/examples/library/assembly/admin.ts
+++ b/examples/library/assembly/admin.ts
@@ -1,0 +1,124 @@
+import {
+  Bytes32,
+  BytesBlob,
+  DecodeError,
+  Decoder,
+  Encoder,
+  Result,
+  TryDecode,
+  TryEncode,
+} from "@fluffylabs/as-lan";
+
+export enum AdminCommandKind {
+  SetMapping = 0,
+  RemoveMapping = 1,
+  Solicit = 2,
+  Forget = 3,
+  Provide = 4,
+}
+
+/**
+ * Tagged union of library admin commands.
+ *
+ * Valid fields per kind:
+ *  - SetMapping:    name, hash, length
+ *  - RemoveMapping: name
+ *  - Solicit:       hash, length
+ *  - Forget:        hash, length
+ *  - Provide:       preimage
+ */
+export class AdminCommand {
+  static setMapping(name: BytesBlob, hash: Bytes32, length: u32): AdminCommand {
+    return new AdminCommand(AdminCommandKind.SetMapping, name, hash, length, null);
+  }
+
+  static removeMapping(name: BytesBlob): AdminCommand {
+    return new AdminCommand(AdminCommandKind.RemoveMapping, name, null, 0, null);
+  }
+
+  static solicit(hash: Bytes32, length: u32): AdminCommand {
+    return new AdminCommand(AdminCommandKind.Solicit, null, hash, length, null);
+  }
+
+  static forget(hash: Bytes32, length: u32): AdminCommand {
+    return new AdminCommand(AdminCommandKind.Forget, null, hash, length, null);
+  }
+
+  static provide(preimage: BytesBlob): AdminCommand {
+    return new AdminCommand(AdminCommandKind.Provide, null, null, 0, preimage);
+  }
+
+  private constructor(
+    public readonly kind: AdminCommandKind,
+    public readonly name: BytesBlob | null,
+    public readonly hash: Bytes32 | null,
+    public readonly length: u32,
+    public readonly preimage: BytesBlob | null,
+  ) {}
+}
+
+export class AdminCommandCodec implements TryDecode<AdminCommand>, TryEncode<AdminCommand> {
+  static create(): AdminCommandCodec {
+    return new AdminCommandCodec();
+  }
+
+  private constructor() {}
+
+  encode(value: AdminCommand, e: Encoder): void {
+    e.u8(u8(value.kind));
+    if (value.kind === AdminCommandKind.SetMapping) {
+      e.bytesVarLen(value.name!);
+      e.bytesFixLen(value.hash!.bytes);
+      e.u32(value.length);
+    } else if (value.kind === AdminCommandKind.RemoveMapping) {
+      e.bytesVarLen(value.name!);
+    } else if (value.kind === AdminCommandKind.Solicit || value.kind === AdminCommandKind.Forget) {
+      e.bytesFixLen(value.hash!.bytes);
+      e.u32(value.length);
+    } else if (value.kind === AdminCommandKind.Provide) {
+      e.bytesVarLen(value.preimage!);
+    }
+  }
+
+  decode(d: Decoder): Result<AdminCommand, DecodeError> {
+    const tag = d.u8();
+    if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
+
+    if (tag === u8(AdminCommandKind.SetMapping)) {
+      const name = d.bytesVarLen();
+      const hashBytes = d.bytesFixLen(32);
+      const length = d.u32();
+      if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
+      return Result.ok<AdminCommand, DecodeError>(
+        AdminCommand.setMapping(name, Bytes32.wrapUnchecked(hashBytes.raw), length),
+      );
+    }
+    if (tag === u8(AdminCommandKind.RemoveMapping)) {
+      const name = d.bytesVarLen();
+      if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
+      return Result.ok<AdminCommand, DecodeError>(AdminCommand.removeMapping(name));
+    }
+    if (tag === u8(AdminCommandKind.Solicit)) {
+      const hashBytes = d.bytesFixLen(32);
+      const length = d.u32();
+      if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
+      return Result.ok<AdminCommand, DecodeError>(
+        AdminCommand.solicit(Bytes32.wrapUnchecked(hashBytes.raw), length),
+      );
+    }
+    if (tag === u8(AdminCommandKind.Forget)) {
+      const hashBytes = d.bytesFixLen(32);
+      const length = d.u32();
+      if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
+      return Result.ok<AdminCommand, DecodeError>(
+        AdminCommand.forget(Bytes32.wrapUnchecked(hashBytes.raw), length),
+      );
+    }
+    if (tag === u8(AdminCommandKind.Provide)) {
+      const preimage = d.bytesVarLen();
+      if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
+      return Result.ok<AdminCommand, DecodeError>(AdminCommand.provide(preimage));
+    }
+    return Result.err<AdminCommand, DecodeError>(DecodeError.InvalidData);
+  }
+}

--- a/examples/library/assembly/admin.ts
+++ b/examples/library/assembly/admin.ts
@@ -1,13 +1,4 @@
-import {
-  Bytes32,
-  BytesBlob,
-  DecodeError,
-  Decoder,
-  Encoder,
-  Result,
-  TryDecode,
-  TryEncode,
-} from "@fluffylabs/as-lan";
+import { Bytes32, BytesBlob, DecodeError, Decoder, Encoder, Result, TryDecode, TryEncode } from "@fluffylabs/as-lan";
 
 export enum AdminCommandKind {
   SetMapping = 0,
@@ -102,17 +93,13 @@ export class AdminCommandCodec implements TryDecode<AdminCommand>, TryEncode<Adm
       const hashBytes = d.bytesFixLen(32);
       const length = d.u32();
       if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
-      return Result.ok<AdminCommand, DecodeError>(
-        AdminCommand.solicit(Bytes32.wrapUnchecked(hashBytes.raw), length),
-      );
+      return Result.ok<AdminCommand, DecodeError>(AdminCommand.solicit(Bytes32.wrapUnchecked(hashBytes.raw), length));
     }
     if (tag === u8(AdminCommandKind.Forget)) {
       const hashBytes = d.bytesFixLen(32);
       const length = d.u32();
       if (d.isError) return Result.err<AdminCommand, DecodeError>(DecodeError.MissingBytes);
-      return Result.ok<AdminCommand, DecodeError>(
-        AdminCommand.forget(Bytes32.wrapUnchecked(hashBytes.raw), length),
-      );
+      return Result.ok<AdminCommand, DecodeError>(AdminCommand.forget(Bytes32.wrapUnchecked(hashBytes.raw), length));
     }
     if (tag === u8(AdminCommandKind.Provide)) {
       const preimage = d.bytesVarLen();

--- a/examples/library/assembly/index.ts
+++ b/examples/library/assembly/index.ts
@@ -1,0 +1,1 @@
+export { accumulate, refine } from "./refine";

--- a/examples/library/assembly/index.ts
+++ b/examples/library/assembly/index.ts
@@ -1,1 +1,2 @@
-export { accumulate, refine } from "./refine";
+export { accumulate } from "./accumulate";
+export { refine } from "./refine";

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -1,0 +1,21 @@
+import { BytesBlob, InvokeIo, Machine } from "@fluffylabs/as-lan";
+import { Assert, Test, TestMachine, test } from "@fluffylabs/as-lan/test";
+
+export const TESTS: Test[] = [
+  test("mock: setInvokeIoR7 writes r7 into InvokeIo after invoke", () => {
+    const assert = Assert.create();
+    TestMachine.setInvokeResult(0, 0); // Halt, r8 = 0
+    TestMachine.setInvokeIoR7(0x0000000500000100); // len=5 in high, ptr=0x100 in low
+
+    const r = Machine.create(BytesBlob.zero(4), 0);
+    if (r.isError) {
+      assert.fail("machine create failed");
+      return assert;
+    }
+    const m = r.okay;
+    const io = InvokeIo.create(1000);
+    m.invoke(io);
+    assert.isEqual(io.getRegister(7), 0x0000000500000100, "r7 written");
+    return assert;
+  }),
+];

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -1,5 +1,6 @@
-import { BytesBlob, InvokeIo, Machine } from "@fluffylabs/as-lan";
+import { Bytes32, BytesBlob, Decoder, Encoder, InvokeIo, Machine } from "@fluffylabs/as-lan";
 import { Assert, Test, TestMachine, test } from "@fluffylabs/as-lan/test";
+import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";
 
 export const TESTS: Test[] = [
   test("mock: setInvokeIoR7 writes r7 into InvokeIo after invoke", () => {
@@ -16,6 +17,32 @@ export const TESTS: Test[] = [
     const io = InvokeIo.create(1000);
     m.invoke(io);
     assert.isEqual(io.getRegister(7), 0x0000000500000100, "r7 written");
+    return assert;
+  }),
+
+  test("storage: LibraryEntry encode/decode round-trip", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0x42;
+    const entry = LibraryEntry.create(hash, 1024);
+    const codec = LibraryEntryCodec.create();
+
+    const enc = Encoder.create();
+    codec.encode(entry, enc);
+    const bytes = enc.finishRaw();
+    assert.isEqual(bytes.length, 36, "encoded length");
+
+    const decoded = codec.decode(Decoder.fromBlob(bytes)).okay!;
+    assert.isEqual(decoded.hash.raw[0], 0x42, "hash byte 0");
+    assert.isEqual(decoded.length, 1024, "length");
+    return assert;
+  }),
+
+  test("storage: libraryKey prepends 'lib:'", () => {
+    const assert = Assert.create();
+    const key = libraryKey("ed25519");
+    const expected = BytesBlob.encodeAscii("lib:ed25519");
+    assert.isEqualBytes(BytesBlob.wrap(key), expected, "key");
     return assert;
   }),
 

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -273,8 +273,10 @@ export const TESTS: Test[] = [
 
     const resp = callRefine(buildDemoInput("panic", 0, 1000, BytesBlob.empty()));
     assert.isEqual(resp.result, -103, "invoke failure");
-    assert.isEqual(resp.data.raw.length, 9, "body length = u8 + u64");
-    assert.isEqual(resp.data.raw[0], 1, "reason = Panic");
+    const dec = Decoder.fromBlob(resp.data.raw);
+    assert.isEqual(dec.u8(), u8(1), "reason = Panic");
+    assert.isEqual(dec.u64(), u64(42), "r8 value preserved");
+    assert.isEqual(dec.isError, false, "body decodes cleanly");
     return assert;
   }),
 
@@ -297,6 +299,9 @@ export const TESTS: Test[] = [
 
   test("mock: setPeekData writes configured bytes to dest", () => {
     const assert = Assert.create();
+    // Clear any error sentinel a prior test may have left in peekResult;
+    // the mock now skips the memory write when peekResult is a negative sentinel.
+    TestMachine.setPeekResult(0);
     const payload = BytesBlob.parseBlob("0xdeadbeef").okay!;
     TestMachine.setPeekData(payload.raw);
 

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -218,6 +218,28 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("refine demo: happy path returns peeked output", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("echo", 0x01, 16);
+    const seed = BytesBlob.parseBlob("0x00").okay!;
+    TestHistoricalLookup.setPreimage(seed.raw);
+    TestMachine.setMachineResult(0); // create OK, id = 0
+    TestMachine.setPokeResult(0);
+    TestMachine.setPagesResult(0);
+    // invoke returns Halt (0); r7 post-invoke = packed ptrAndLen(ptr=0xFEFF2000, len=3)
+    TestMachine.setInvokeResult(0, 0);
+    TestMachine.setInvokeIoR7((i64(3) << 32) | i64(0xFEFF2000));
+    const expected = BytesBlob.parseBlob("0x010203").okay!;
+    TestMachine.setPeekData(expected.raw);
+    TestMachine.setExpungeResult(0);
+
+    const input = buildDemoInput("echo", 0, 1000, BytesBlob.parseBlob("0xaabb").okay!);
+    const resp = callRefine(input);
+    assert.isEqual(resp.result, 0, "ok");
+    assert.isEqualBytes(resp.data, expected, "peeked output");
+    return assert;
+  }),
+
   test("mock: setPeekData writes configured bytes to dest", () => {
     const assert = Assert.create();
     const payload = BytesBlob.parseBlob("0xdeadbeef").okay!;

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -186,6 +186,22 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("refine: admin path rejects trailing bytes with -105", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    const codec = AdminCommandCodec.create();
+    const body = Encoder.create();
+    codec.encode(AdminCommand.solicit(hash, 1), body);
+
+    const input = Encoder.create();
+    input.u8(1); // admin tag
+    input.bytesFixLen(BytesBlob.wrap(body.finishRaw()));
+    input.u8(0xff); // trailing junk
+    const resp = callRefine(input.finishRaw());
+    assert.isEqual(resp.result, -105, "trailing bytes rejected");
+    return assert;
+  }),
+
   test("refine: admin path rejects malformed bytes with -105", () => {
     const assert = Assert.create();
     const input = Encoder.create();
@@ -193,6 +209,18 @@ export const TESTS: Test[] = [
     input.u8(0x99); // unknown AdminCommand tag
     const resp = callRefine(input.finishRaw());
     assert.isEqual(resp.result, -105, "malformed");
+    return assert;
+  }),
+
+  test("refine demo: trailing bytes after payload return -106", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("ok", 0x01, 16);
+    const valid = buildDemoInput("ok", 0, 1000, BytesBlob.empty());
+    const withTrail = new Uint8Array(valid.length + 1);
+    withTrail.set(valid, 0);
+    withTrail[valid.length] = 0xff;
+    const resp = callRefine(withTrail);
+    assert.isEqual(resp.result, -106, "trailing bytes after demo payload rejected");
     return assert;
   }),
 

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -240,6 +240,51 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("refine demo: invalid entrypoint returns -3", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("bad", 0xaa, 16);
+    TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
+    TestMachine.setMachineResult(-9); // HUH sentinel (InvalidEntryPoint)
+
+    const resp = callRefine(buildDemoInput("bad", 0, 1000, BytesBlob.empty()));
+    assert.isEqual(resp.result, -3, "invalid entrypoint");
+    return assert;
+  }),
+
+  test("refine demo: invoke Panic returns -4 with reason+r8", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("panic", 0xbb, 16);
+    TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
+    TestMachine.setMachineResult(0);
+    TestMachine.setPagesResult(0);
+    TestMachine.setPokeResult(0);
+    TestMachine.setInvokeResult(1, 42); // Panic, r8=42
+    TestMachine.setExpungeResult(0);
+
+    const resp = callRefine(buildDemoInput("panic", 0, 1000, BytesBlob.empty()));
+    assert.isEqual(resp.result, -4, "invoke failure");
+    assert.isEqual(resp.data.raw.length, 9, "body length = u8 + u64");
+    assert.isEqual(resp.data.raw[0], 1, "reason = Panic");
+    return assert;
+  }),
+
+  test("refine demo: peek OOB returns -5", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("oob", 0xcc, 16);
+    TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
+    TestMachine.setMachineResult(0);
+    TestMachine.setPagesResult(0);
+    TestMachine.setPokeResult(0);
+    TestMachine.setInvokeResult(0, 0); // Halt
+    TestMachine.setInvokeIoR7((i64(3) << 32) | i64(0xfeff9000));
+    TestMachine.setPeekResult(-3); // OOB sentinel
+    TestMachine.setExpungeResult(0);
+
+    const resp = callRefine(buildDemoInput("oob", 0, 1000, BytesBlob.empty()));
+    assert.isEqual(resp.result, -5, "peek OOB");
+    return assert;
+  }),
+
   test("mock: setPeekData writes configured bytes to dest", () => {
     const assert = Assert.create();
     const payload = BytesBlob.parseBlob("0xdeadbeef").okay!;

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -1,5 +1,6 @@
 import { Bytes32, BytesBlob, Decoder, Encoder, InvokeIo, Machine } from "@fluffylabs/as-lan";
 import { Assert, Test, TestMachine, test } from "@fluffylabs/as-lan/test";
+import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";
 
 export const TESTS: Test[] = [
@@ -43,6 +44,91 @@ export const TESTS: Test[] = [
     const key = libraryKey("ed25519");
     const expected = BytesBlob.encodeAscii("lib:ed25519");
     assert.isEqualBytes(BytesBlob.wrap(key), expected, "key");
+    return assert;
+  }),
+
+  test("admin: SetMapping round-trip", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0xaa;
+    const cmd = AdminCommand.setMapping(BytesBlob.encodeAscii("ed25519"), hash, 4096);
+    const codec = AdminCommandCodec.create();
+
+    const enc = Encoder.create();
+    codec.encode(cmd, enc);
+    const decoded = codec.decode(Decoder.fromBlob(enc.finishRaw())).okay!;
+    assert.isEqual<u32>(decoded.kind, AdminCommandKind.SetMapping, "kind");
+    assert.isEqualBytes(decoded.name!, BytesBlob.encodeAscii("ed25519"), "name");
+    assert.isEqual(decoded.hash!.raw[0], 0xaa, "hash");
+    assert.isEqual(decoded.length, 4096, "length");
+    return assert;
+  }),
+
+  test("admin: RemoveMapping round-trip", () => {
+    const assert = Assert.create();
+    const cmd = AdminCommand.removeMapping(BytesBlob.encodeAscii("blake2b"));
+    const codec = AdminCommandCodec.create();
+
+    const enc = Encoder.create();
+    codec.encode(cmd, enc);
+    const decoded = codec.decode(Decoder.fromBlob(enc.finishRaw())).okay!;
+    assert.isEqual<u32>(decoded.kind, AdminCommandKind.RemoveMapping, "kind");
+    assert.isEqualBytes(decoded.name!, BytesBlob.encodeAscii("blake2b"), "name");
+    return assert;
+  }),
+
+  test("admin: Solicit round-trip", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0xbb;
+    const cmd = AdminCommand.solicit(hash, 2048);
+    const codec = AdminCommandCodec.create();
+
+    const enc = Encoder.create();
+    codec.encode(cmd, enc);
+    const decoded = codec.decode(Decoder.fromBlob(enc.finishRaw())).okay!;
+    assert.isEqual<u32>(decoded.kind, AdminCommandKind.Solicit, "kind");
+    assert.isEqual(decoded.hash!.raw[0], 0xbb, "hash");
+    assert.isEqual(decoded.length, 2048, "length");
+    return assert;
+  }),
+
+  test("admin: Forget round-trip", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0xcc;
+    const cmd = AdminCommand.forget(hash, 512);
+    const codec = AdminCommandCodec.create();
+
+    const enc = Encoder.create();
+    codec.encode(cmd, enc);
+    const decoded = codec.decode(Decoder.fromBlob(enc.finishRaw())).okay!;
+    assert.isEqual<u32>(decoded.kind, AdminCommandKind.Forget, "kind");
+    assert.isEqual(decoded.hash!.raw[0], 0xcc, "hash");
+    assert.isEqual(decoded.length, 512, "length");
+    return assert;
+  }),
+
+  test("admin: Provide round-trip", () => {
+    const assert = Assert.create();
+    const preimage = BytesBlob.parseBlob("0x01020304").okay!;
+    const cmd = AdminCommand.provide(preimage);
+    const codec = AdminCommandCodec.create();
+
+    const enc = Encoder.create();
+    codec.encode(cmd, enc);
+    const decoded = codec.decode(Decoder.fromBlob(enc.finishRaw())).okay!;
+    assert.isEqual<u32>(decoded.kind, AdminCommandKind.Provide, "kind");
+    assert.isEqualBytes(decoded.preimage!, preimage, "preimage");
+    return assert;
+  }),
+
+  test("admin: decode rejects unknown tag", () => {
+    const assert = Assert.create();
+    const codec = AdminCommandCodec.create();
+    const bytes = BytesBlob.parseBlob("0x99").okay!.raw;
+    const r = codec.decode(Decoder.fromBlob(bytes));
+    assert.isEqual(r.isError, true, "should error");
     return assert;
   }),
 

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -2,6 +2,7 @@ import { Bytes32, BytesBlob, Decoder, Encoder, InvokeIo, Machine } from "@fluffy
 import { Assert, Test, TestMachine, test } from "@fluffylabs/as-lan/test";
 import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";
+import { callRefine } from "./test-helpers";
 
 export const TESTS: Test[] = [
   test("mock: setInvokeIoR7 writes r7 into InvokeIo after invoke", () => {
@@ -129,6 +130,20 @@ export const TESTS: Test[] = [
     const bytes = BytesBlob.parseBlob("0x99").okay!.raw;
     const r = codec.decode(Decoder.fromBlob(bytes));
     assert.isEqual(r.isError, true, "should error");
+    return assert;
+  }),
+
+  test("refine: unknown tag returns -7", () => {
+    const assert = Assert.create();
+    const resp = callRefine(BytesBlob.parseBlob("0x99").okay!.raw); // tag=0x99 unknown
+    assert.isEqual(resp.result, -7, "result");
+    return assert;
+  }),
+
+  test("refine: empty payload returns -7", () => {
+    const assert = Assert.create();
+    const resp = callRefine(new Uint8Array(0));
+    assert.isEqual(resp.result, -7, "result");
     return assert;
   }),
 

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -308,6 +308,39 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("refine demo: oversized output length returns -104 without allocating", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("huge", 0xdd, 16);
+    TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
+    TestMachine.setMachineResult(0);
+    TestMachine.setPagesResult(0);
+    TestMachine.setPokeResult(0);
+    TestMachine.setInvokeResult(0, 0); // Halt
+    // r7 = ptrAndLen(ptr=0, len=0xFFFFFFFF) — wildly larger than MAX_OUTPUT_LEN.
+    TestMachine.setInvokeIoR7((i64(0xffffffff) << 32) | i64(0));
+    TestMachine.setExpungeResult(0);
+
+    const resp = callRefine(buildDemoInput("huge", 0, 1000, BytesBlob.empty()));
+    assert.isEqual(resp.result, -104, "oversized outLen capped before alloc");
+    return assert;
+  }),
+
+  test("refine demo: trailing bytes in stored entry return -100", () => {
+    const assert = Assert.create();
+    // Valid 36-byte LibraryEntry + 1 trailing junk byte.
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0x77;
+    const entry = LibraryEntry.create(hash, 32);
+    const enc = Encoder.create();
+    LibraryEntryCodec.create().encode(entry, enc);
+    enc.u8(0xff); // trailing junk
+    TestStorage.set(BytesBlob.wrap(libraryKey("trail")), BytesBlob.wrap(enc.finishRaw()));
+
+    const resp = callRefine(buildDemoInput("trail", 0, 1000, BytesBlob.empty()));
+    assert.isEqual(resp.result, -100, "trailing bytes in stored entry rejected");
+    return assert;
+  }),
+
   test("refine demo: peek OOB returns -104", () => {
     const assert = Assert.create();
     seedLibraryMapping("oob", 0xcc, 16);

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -18,4 +18,21 @@ export const TESTS: Test[] = [
     assert.isEqual(io.getRegister(7), 0x0000000500000100, "r7 written");
     return assert;
   }),
+
+  test("mock: setPeekData writes configured bytes to dest", () => {
+    const assert = Assert.create();
+    const payload = BytesBlob.parseBlob("0xdeadbeef").okay!;
+    TestMachine.setPeekData(payload.raw);
+
+    const r = Machine.create(BytesBlob.zero(4), 0);
+    if (r.isError) {
+      assert.fail("machine create failed");
+      return assert;
+    }
+    const m = r.okay;
+    const buf = BytesBlob.zero(4);
+    m.peek(0, buf);
+    assert.isEqualBytes(buf, payload, "peek data");
+    return assert;
+  }),
 ];

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -1,6 +1,5 @@
 import { Bytes32, BytesBlob, Decoder, Encoder, InvokeIo, Machine } from "@fluffylabs/as-lan";
-import { Assert, Test, TestMachine, test } from "@fluffylabs/as-lan/test";
-import { TestHistoricalLookup, TestStorage } from "@fluffylabs/as-lan/test";
+import { Assert, Test, TestHistoricalLookup, TestMachine, TestStorage, test } from "@fluffylabs/as-lan/test";
 import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";
 import { callRefine } from "./test-helpers";
@@ -228,7 +227,7 @@ export const TESTS: Test[] = [
     TestMachine.setPagesResult(0);
     // invoke returns Halt (0); r7 post-invoke = packed ptrAndLen(ptr=0xFEFF2000, len=3)
     TestMachine.setInvokeResult(0, 0);
-    TestMachine.setInvokeIoR7((i64(3) << 32) | i64(0xFEFF2000));
+    TestMachine.setInvokeIoR7((i64(3) << 32) | i64(0xfeff2000));
     const expected = BytesBlob.parseBlob("0x010203").okay!;
     TestMachine.setPeekData(expected.raw);
     TestMachine.setExpungeResult(0);

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -147,6 +147,36 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
+  test("refine: admin path round-trips SetMapping canonically", () => {
+    const assert = Assert.create();
+    const hash = Bytes32.zero();
+    hash.raw[0] = 0xaa;
+    const cmd = AdminCommand.setMapping(BytesBlob.encodeAscii("ed25519"), hash, 4096);
+    const codec = AdminCommandCodec.create();
+    const body = Encoder.create();
+    codec.encode(cmd, body);
+    const bodyBytes = body.finishRaw();
+
+    const input = Encoder.create();
+    input.u8(1); // admin tag
+    input.bytesFixLen(BytesBlob.wrap(bodyBytes));
+
+    const resp = callRefine(input.finishRaw());
+    assert.isEqual(resp.result, 0, "ok");
+    assert.isEqualBytes(resp.data, BytesBlob.wrap(bodyBytes), "canonical body");
+    return assert;
+  }),
+
+  test("refine: admin path rejects malformed bytes with -6", () => {
+    const assert = Assert.create();
+    const input = Encoder.create();
+    input.u8(1); // admin tag
+    input.u8(0x99); // unknown AdminCommand tag
+    const resp = callRefine(input.finishRaw());
+    assert.isEqual(resp.result, -6, "malformed");
+    return assert;
+  }),
+
   test("mock: setPeekData writes configured bytes to dest", () => {
     const assert = Assert.create();
     const payload = BytesBlob.parseBlob("0xdeadbeef").okay!;

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -152,17 +152,17 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
-  test("refine: unknown tag returns -7", () => {
+  test("refine: unknown tag returns -106", () => {
     const assert = Assert.create();
     const resp = callRefine(BytesBlob.parseBlob("0x99").okay!.raw); // tag=0x99 unknown
-    assert.isEqual(resp.result, -7, "result");
+    assert.isEqual(resp.result, -106, "result");
     return assert;
   }),
 
-  test("refine: empty payload returns -7", () => {
+  test("refine: empty payload returns -106", () => {
     const assert = Assert.create();
     const resp = callRefine(new Uint8Array(0));
-    assert.isEqual(resp.result, -7, "result");
+    assert.isEqual(resp.result, -106, "result");
     return assert;
   }),
 
@@ -186,34 +186,45 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
-  test("refine: admin path rejects malformed bytes with -6", () => {
+  test("refine: admin path rejects malformed bytes with -105", () => {
     const assert = Assert.create();
     const input = Encoder.create();
     input.u8(1); // admin tag
     input.u8(0x99); // unknown AdminCommand tag
     const resp = callRefine(input.finishRaw());
-    assert.isEqual(resp.result, -6, "malformed");
+    assert.isEqual(resp.result, -105, "malformed");
     return assert;
   }),
 
-  test("refine demo: unknown library name returns -1", () => {
+  test("refine demo: unknown library name returns -100", () => {
     const assert = Assert.create();
     TestStorage.set(BytesBlob.wrap(libraryKey("missing")), null);
 
     const input = buildDemoInput("missing", 0, 1000, BytesBlob.empty());
     const resp = callRefine(input);
-    assert.isEqual(resp.result, -1, "unknown library");
+    assert.isEqual(resp.result, -100, "unknown library");
     return assert;
   }),
 
-  test("refine demo: preimage unavailable returns -2", () => {
+  test("refine demo: malformed stored entry returns -100", () => {
+    const assert = Assert.create();
+    // Store a value that is too short to decode a LibraryEntry (hash+length = 36 bytes).
+    TestStorage.set(BytesBlob.wrap(libraryKey("corrupt")), BytesBlob.parseBlob("0xdead").okay!);
+
+    const input = buildDemoInput("corrupt", 0, 1000, BytesBlob.empty());
+    const resp = callRefine(input);
+    assert.isEqual(resp.result, -100, "malformed entry treated as unknown");
+    return assert;
+  }),
+
+  test("refine demo: preimage unavailable returns -101", () => {
     const assert = Assert.create();
     seedLibraryMapping("ed25519", 0xee, 64);
     TestHistoricalLookup.setNone();
 
     const input = buildDemoInput("ed25519", 0, 1000, BytesBlob.empty());
     const resp = callRefine(input);
-    assert.isEqual(resp.result, -2, "preimage unavailable");
+    assert.isEqual(resp.result, -101, "preimage unavailable");
     return assert;
   }),
 
@@ -239,18 +250,18 @@ export const TESTS: Test[] = [
     return assert;
   }),
 
-  test("refine demo: invalid entrypoint returns -3", () => {
+  test("refine demo: invalid entrypoint returns -102", () => {
     const assert = Assert.create();
     seedLibraryMapping("bad", 0xaa, 16);
     TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
     TestMachine.setMachineResult(-9); // HUH sentinel (InvalidEntryPoint)
 
     const resp = callRefine(buildDemoInput("bad", 0, 1000, BytesBlob.empty()));
-    assert.isEqual(resp.result, -3, "invalid entrypoint");
+    assert.isEqual(resp.result, -102, "invalid entrypoint");
     return assert;
   }),
 
-  test("refine demo: invoke Panic returns -4 with reason+r8", () => {
+  test("refine demo: invoke Panic returns -103 with reason+r8", () => {
     const assert = Assert.create();
     seedLibraryMapping("panic", 0xbb, 16);
     TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
@@ -261,13 +272,13 @@ export const TESTS: Test[] = [
     TestMachine.setExpungeResult(0);
 
     const resp = callRefine(buildDemoInput("panic", 0, 1000, BytesBlob.empty()));
-    assert.isEqual(resp.result, -4, "invoke failure");
+    assert.isEqual(resp.result, -103, "invoke failure");
     assert.isEqual(resp.data.raw.length, 9, "body length = u8 + u64");
     assert.isEqual(resp.data.raw[0], 1, "reason = Panic");
     return assert;
   }),
 
-  test("refine demo: peek OOB returns -5", () => {
+  test("refine demo: peek OOB returns -104", () => {
     const assert = Assert.create();
     seedLibraryMapping("oob", 0xcc, 16);
     TestHistoricalLookup.setPreimage(BytesBlob.parseBlob("0x00").okay!.raw);
@@ -280,7 +291,7 @@ export const TESTS: Test[] = [
     TestMachine.setExpungeResult(0);
 
     const resp = callRefine(buildDemoInput("oob", 0, 1000, BytesBlob.empty()));
-    assert.isEqual(resp.result, -5, "peek OOB");
+    assert.isEqual(resp.result, -104, "peek OOB");
     return assert;
   }),
 

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -1,8 +1,28 @@
 import { Bytes32, BytesBlob, Decoder, Encoder, InvokeIo, Machine } from "@fluffylabs/as-lan";
 import { Assert, Test, TestMachine, test } from "@fluffylabs/as-lan/test";
+import { TestHistoricalLookup, TestStorage } from "@fluffylabs/as-lan/test";
 import { AdminCommand, AdminCommandCodec, AdminCommandKind } from "./admin";
 import { LibraryEntry, LibraryEntryCodec, libraryKey } from "./storage";
 import { callRefine } from "./test-helpers";
+
+function buildDemoInput(name: string, entrypoint: u32, gas: u64, payload: BytesBlob): Uint8Array {
+  const enc = Encoder.create();
+  enc.u8(0); // demo tag
+  enc.bytesVarLen(BytesBlob.encodeAscii(name));
+  enc.u32(entrypoint);
+  enc.u64(gas);
+  enc.bytesVarLen(payload);
+  return enc.finishRaw();
+}
+
+function seedLibraryMapping(name: string, hashByte0: u8, length: u32): void {
+  const h = Bytes32.zero();
+  h.raw[0] = hashByte0;
+  const e = LibraryEntry.create(h, length);
+  const enc = Encoder.create();
+  LibraryEntryCodec.create().encode(e, enc);
+  TestStorage.set(BytesBlob.wrap(libraryKey(name)), BytesBlob.wrap(enc.finishRaw()));
+}
 
 export const TESTS: Test[] = [
   test("mock: setInvokeIoR7 writes r7 into InvokeIo after invoke", () => {
@@ -174,6 +194,27 @@ export const TESTS: Test[] = [
     input.u8(0x99); // unknown AdminCommand tag
     const resp = callRefine(input.finishRaw());
     assert.isEqual(resp.result, -6, "malformed");
+    return assert;
+  }),
+
+  test("refine demo: unknown library name returns -1", () => {
+    const assert = Assert.create();
+    TestStorage.set(BytesBlob.wrap(libraryKey("missing")), null);
+
+    const input = buildDemoInput("missing", 0, 1000, BytesBlob.empty());
+    const resp = callRefine(input);
+    assert.isEqual(resp.result, -1, "unknown library");
+    return assert;
+  }),
+
+  test("refine demo: preimage unavailable returns -2", () => {
+    const assert = Assert.create();
+    seedLibraryMapping("ed25519", 0xee, 64);
+    TestHistoricalLookup.setNone();
+
+    const input = buildDemoInput("ed25519", 0, 1000, BytesBlob.empty());
+    const resp = callRefine(input);
+    assert.isEqual(resp.result, -2, "preimage unavailable");
     return assert;
   }),
 

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,11 +1,25 @@
-import { BytesBlob, Decoder, Encoder, RefineContext } from "@fluffylabs/as-lan";
+import {
+  BytesBlob,
+  Decoder,
+  Encoder,
+  ExitReason,
+  InvokeIo,
+  PageAccess,
+  RefineContext,
+} from "@fluffylabs/as-lan";
 import { AdminCommandCodec } from "./admin";
 import { LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
 const ERR_UNKNOWN_LIB: i64 = -1;
 const ERR_PREIMAGE_MISS: i64 = -2;
+const ERR_INVALID_ENTRYPOINT: i64 = -3;
+const ERR_INVOKE_FAILURE: i64 = -4;
+const ERR_OOB: i64 = -5;
 const ERR_ADMIN_MALFORMED: i64 = -6;
 const ERR_PARSE: i64 = -7;
+
+const INPUT_ADDR: u32 = 0xfeff0000;
+const PAGE_SIZE: u32 = 4096;
 
 export function refine(ptr: u32, len: u32): u64 {
   const ctx = RefineContext.create();
@@ -39,13 +53,57 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const entry = entryR.okay!;
 
   // Fetch preimage (historical lookup — required in refine context)
-  const preimage = ctx.preimages().historicalLookup(entry.hash);
-  if (!preimage.isSome) return ctx.respond(ERR_PREIMAGE_MISS);
+  const preimageOpt = ctx.preimages().historicalLookup(entry.hash);
+  if (!preimageOpt.isSome) return ctx.respond(ERR_PREIMAGE_MISS);
+  const code = preimageOpt.val!;
 
-  // TODO next task: spawn machine, poke payload, invoke, peek, expunge.
-  // Keep `entrypoint`, `gas`, `callPayload` for that wiring.
-  const _ = entrypoint + u32(gas) + callPayload.length;
-  return ctx.respond(0);
+  // Spawn inner machine
+  const machineR = ctx.machine(code, entrypoint);
+  if (machineR.isError) return ctx.respond(ERR_INVALID_ENTRYPOINT);
+  const m = machineR.okay;
+
+  // Allocate RW pages at INPUT_ADDR to fit the payload (at least one page).
+  const startPage: u32 = INPUT_ADDR / PAGE_SIZE;
+  const pageCount: u32 =
+    callPayload.length === 0 ? 1 : (u32(callPayload.length) + PAGE_SIZE - 1) / PAGE_SIZE;
+  m.pages(startPage, pageCount, PageAccess.ReadWrite);
+
+  // Poke payload into inner PVM memory.
+  const pokeR = m.poke(INPUT_ADDR, callPayload);
+  if (pokeR.isError) {
+    m.expunge();
+    return ctx.respond(ERR_OOB);
+  }
+
+  // Build IO (SPI convention: r7 = input ptr, r8 = input len) and invoke.
+  const io = InvokeIo.create(gas);
+  io.setRegister(7, u64(INPUT_ADDR));
+  io.setRegister(8, u64(callPayload.length));
+  const outcome = m.invoke(io);
+
+  if (outcome.reason !== ExitReason.Halt) {
+    m.expunge();
+    const errEnc = Encoder.create();
+    errEnc.u8(u8(outcome.reason));
+    errEnc.u64(u64(outcome.r8));
+    return ctx.respond(ERR_INVOKE_FAILURE, errEnc.finishRaw());
+  }
+
+  // Unpack r7 = ptrAndLen (low 32 = ptr, high 32 = len).
+  const r7 = io.getRegister(7);
+  const outAddr: u32 = u32(r7 & 0xffffffff);
+  const outLen: u32 = u32(r7 >> 32);
+
+  const outBuf = BytesBlob.zero(outLen);
+  if (outLen > 0) {
+    const peekR = m.peek(outAddr, outBuf);
+    if (peekR.isError) {
+      m.expunge();
+      return ctx.respond(ERR_OOB);
+    }
+  }
+  m.expunge();
+  return ctx.respond(0, outBuf.raw);
 }
 
 function handleAdmin(ctx: RefineContext, rest: BytesBlob): u64 {

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,5 +1,7 @@
-import { RefineContext } from "@fluffylabs/as-lan";
+import { BytesBlob, Decoder, Encoder, RefineContext } from "@fluffylabs/as-lan";
+import { AdminCommandCodec } from "./admin";
 
+const ERR_ADMIN_MALFORMED: i64 = -6;
 const ERR_PARSE: i64 = -7;
 
 export function refine(ptr: u32, len: u32): u64 {
@@ -10,13 +12,19 @@ export function refine(ptr: u32, len: u32): u64 {
   if (payload.length < 1) return ctx.respond(ERR_PARSE);
 
   const tag = payload.raw[0];
-  if (tag === 0) {
-    // demo path — next task
-    return ctx.respond(ERR_PARSE);
-  }
-  if (tag === 1) {
-    // admin path — next task
-    return ctx.respond(ERR_PARSE);
-  }
+  const rest = BytesBlob.wrap(payload.raw.subarray(1));
+
+  if (tag === 1) return handleAdmin(ctx, rest);
+  if (tag === 0) return ctx.respond(ERR_PARSE); // demo — next task
   return ctx.respond(ERR_PARSE);
+}
+
+function handleAdmin(ctx: RefineContext, rest: BytesBlob): u64 {
+  const codec = AdminCommandCodec.create();
+  const r = codec.decode(Decoder.fromBlob(rest.raw));
+  if (r.isError) return ctx.respond(ERR_ADMIN_MALFORMED);
+
+  const enc = Encoder.create();
+  codec.encode(r.okay!, enc);
+  return ctx.respond(0, enc.finishRaw());
 }

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,0 +1,11 @@
+import { AccumulateContext, RefineContext } from "@fluffylabs/as-lan";
+
+export function refine(_ptr: u32, _len: u32): u64 {
+  const ctx = RefineContext.create();
+  return ctx.respond(0);
+}
+
+export function accumulate(_ptr: u32, _len: u32): u64 {
+  const ctx = AccumulateContext.create();
+  return ctx.respond(0);
+}

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,6 +1,22 @@
 import { RefineContext } from "@fluffylabs/as-lan";
 
-export function refine(_ptr: u32, _len: u32): u64 {
+const ERR_PARSE: i64 = -7;
+
+export function refine(ptr: u32, len: u32): u64 {
   const ctx = RefineContext.create();
-  return ctx.respond(0);
+  const args = ctx.parseArgs(ptr, len);
+  const payload = args.payload;
+
+  if (payload.length < 1) return ctx.respond(ERR_PARSE);
+
+  const tag = payload.raw[0];
+  if (tag === 0) {
+    // demo path — next task
+    return ctx.respond(ERR_PARSE);
+  }
+  if (tag === 1) {
+    // admin path — next task
+    return ctx.respond(ERR_PARSE);
+  }
+  return ctx.respond(ERR_PARSE);
 }

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,12 +1,4 @@
-import {
-  BytesBlob,
-  Decoder,
-  Encoder,
-  ExitReason,
-  InvokeIo,
-  PageAccess,
-  RefineContext,
-} from "@fluffylabs/as-lan";
+import { BytesBlob, Decoder, Encoder, ExitReason, InvokeIo, PageAccess, RefineContext } from "@fluffylabs/as-lan";
 import { AdminCommandCodec } from "./admin";
 import { LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
@@ -64,8 +56,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
 
   // Allocate RW pages at INPUT_ADDR to fit the payload (at least one page).
   const startPage: u32 = INPUT_ADDR / PAGE_SIZE;
-  const pageCount: u32 =
-    callPayload.length === 0 ? 1 : (u32(callPayload.length) + PAGE_SIZE - 1) / PAGE_SIZE;
+  const pageCount: u32 = callPayload.length === 0 ? 1 : (u32(callPayload.length) + PAGE_SIZE - 1) / PAGE_SIZE;
   m.pages(startPage, pageCount, PageAccess.ReadWrite);
 
   // Poke payload into inner PVM memory.

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -15,6 +15,10 @@ const ERR_PARSE: i64 = -106;
 
 const INPUT_ADDR: u32 = 0xfeff0000;
 const PAGE_SIZE: u32 = 4096;
+// Cap on the output length the inner PVM may report in r7. Bounds the
+// response-buffer allocation so a buggy or malicious library cannot force
+// a multi-GB allocation before peek() gets a chance to surface the error.
+const MAX_OUTPUT_LEN: u32 = 64 * 1024;
 
 export function refine(ptr: u32, len: u32): u64 {
   const ctx = RefineContext.create();
@@ -44,8 +48,9 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const storage = ctx.serviceData();
   const stored = storage.read(libraryKeyFromBlob(name));
   if (!stored.isSome) return ctx.respond(ERR_UNKNOWN_LIB);
-  const entryR = LibraryEntryCodec.create().decode(Decoder.fromBlob(stored.val!));
-  if (entryR.isError) return ctx.respond(ERR_UNKNOWN_LIB);
+  const entryDecoder = Decoder.fromBlob(stored.val!);
+  const entryR = LibraryEntryCodec.create().decode(entryDecoder);
+  if (entryR.isError || !entryDecoder.isFinished()) return ctx.respond(ERR_UNKNOWN_LIB);
   const entry = entryR.okay!;
 
   // Fetch preimage (historical lookup — required in refine context)
@@ -88,6 +93,10 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const r7 = io.getRegister(7);
   const outAddr: u32 = u32(r7 & 0xffffffff);
   const outLen: u32 = u32(r7 >> 32);
+  if (outLen > MAX_OUTPUT_LEN) {
+    m.expunge();
+    return ctx.respond(ERR_OOB);
+  }
 
   const outBuf = BytesBlob.zero(outLen);
   if (outLen > 0) {

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -38,6 +38,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const gas = d.u64();
   const callPayload = d.bytesVarLen();
   if (d.isError) return ctx.respond(ERR_PARSE);
+  if (!d.isFinished()) return ctx.respond(ERR_PARSE);
 
   // Resolve name → LibraryEntry via storage
   const storage = ctx.serviceData();
@@ -102,8 +103,10 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
 
 function handleAdmin(ctx: RefineContext, rest: BytesBlob): u64 {
   const codec = AdminCommandCodec.create();
-  const r = codec.decode(Decoder.fromBlob(rest.raw));
+  const d = Decoder.fromBlob(rest.raw);
+  const r = codec.decode(d);
   if (r.isError) return ctx.respond(ERR_ADMIN_MALFORMED);
+  if (!d.isFinished()) return ctx.respond(ERR_ADMIN_MALFORMED);
 
   const enc = Encoder.create();
   codec.encode(r.okay!, enc);

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -2,13 +2,16 @@ import { BytesBlob, Decoder, Encoder, ExitReason, InvokeIo, PageAccess, RefineCo
 import { AdminCommandCodec } from "./admin";
 import { LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
-const ERR_UNKNOWN_LIB: i64 = -1;
-const ERR_PREIMAGE_MISS: i64 = -2;
-const ERR_INVALID_ENTRYPOINT: i64 = -3;
-const ERR_INVOKE_FAILURE: i64 = -4;
-const ERR_OOB: i64 = -5;
-const ERR_ADMIN_MALFORMED: i64 = -6;
-const ERR_PARSE: i64 = -7;
+// Error codes use the -100..-106 range to avoid overlap with EcalliResult
+// sentinels (NONE=-1, OOB=-3, WHO=-4, FULL=-5, HUH=-9) that may appear in
+// the same `ecalliResult` field when raw ecalli results leak through.
+const ERR_UNKNOWN_LIB: i64 = -100;
+const ERR_PREIMAGE_MISS: i64 = -101;
+const ERR_INVALID_ENTRYPOINT: i64 = -102;
+const ERR_INVOKE_FAILURE: i64 = -103;
+const ERR_OOB: i64 = -104;
+const ERR_ADMIN_MALFORMED: i64 = -105;
+const ERR_PARSE: i64 = -106;
 
 const INPUT_ADDR: u32 = 0xfeff0000;
 const PAGE_SIZE: u32 = 4096;

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,6 +1,9 @@
 import { BytesBlob, Decoder, Encoder, RefineContext } from "@fluffylabs/as-lan";
 import { AdminCommandCodec } from "./admin";
+import { LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
+const ERR_UNKNOWN_LIB: i64 = -1;
+const ERR_PREIMAGE_MISS: i64 = -2;
 const ERR_ADMIN_MALFORMED: i64 = -6;
 const ERR_PARSE: i64 = -7;
 
@@ -14,9 +17,35 @@ export function refine(ptr: u32, len: u32): u64 {
   const tag = payload.raw[0];
   const rest = BytesBlob.wrap(payload.raw.subarray(1));
 
+  if (tag === 0) return handleDemo(ctx, rest);
   if (tag === 1) return handleAdmin(ctx, rest);
-  if (tag === 0) return ctx.respond(ERR_PARSE); // demo — next task
   return ctx.respond(ERR_PARSE);
+}
+
+function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
+  const d = Decoder.fromBlob(rest.raw);
+  const name = d.bytesVarLen();
+  const entrypoint = d.u32();
+  const gas = d.u64();
+  const callPayload = d.bytesVarLen();
+  if (d.isError) return ctx.respond(ERR_PARSE);
+
+  // Resolve name → LibraryEntry via storage
+  const storage = ctx.serviceData();
+  const stored = storage.read(libraryKeyFromBlob(name));
+  if (!stored.isSome) return ctx.respond(ERR_UNKNOWN_LIB);
+  const entryR = LibraryEntryCodec.create().decode(Decoder.fromBlob(stored.val!));
+  if (entryR.isError) return ctx.respond(ERR_UNKNOWN_LIB);
+  const entry = entryR.okay!;
+
+  // Fetch preimage (historical lookup — required in refine context)
+  const preimage = ctx.preimages().historicalLookup(entry.hash);
+  if (!preimage.isSome) return ctx.respond(ERR_PREIMAGE_MISS);
+
+  // TODO next task: spawn machine, poke payload, invoke, peek, expunge.
+  // Keep `entrypoint`, `gas`, `callPayload` for that wiring.
+  const _ = entrypoint + u32(gas) + callPayload.length;
+  return ctx.respond(0);
 }
 
 function handleAdmin(ctx: RefineContext, rest: BytesBlob): u64 {

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -2,16 +2,22 @@ import { BytesBlob, Decoder, Encoder, ExitReason, InvokeIo, PageAccess, RefineCo
 import { AdminCommandCodec } from "./admin";
 import { LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
-// Error codes use the -100..-106 range to avoid overlap with EcalliResult
-// sentinels (NONE=-1, OOB=-3, WHO=-4, FULL=-5, HUH=-9) that may appear in
-// the same `ecalliResult` field when raw ecalli results leak through.
-const ERR_UNKNOWN_LIB: i64 = -100;
-const ERR_PREIMAGE_MISS: i64 = -101;
-const ERR_INVALID_ENTRYPOINT: i64 = -102;
-const ERR_INVOKE_FAILURE: i64 = -103;
-const ERR_OOB: i64 = -104;
-const ERR_ADMIN_MALFORMED: i64 = -105;
-const ERR_PARSE: i64 = -106;
+/**
+ * Error codes returned in `Response.result` (decoded by the caller).
+ *
+ * Values live in the `-100..-106` range to avoid overlap with `EcalliResult`
+ * sentinels (NONE=-1, OOB=-3, WHO=-4, FULL=-5, HUH=-9) that may appear in the
+ * same field when raw ecalli results leak through.
+ */
+export enum LibraryError {
+  UnknownLib = -100,
+  PreimageMiss = -101,
+  InvalidEntryPoint = -102,
+  InvokeFailure = -103,
+  Oob = -104,
+  AdminMalformed = -105,
+  Parse = -106,
+}
 
 const INPUT_ADDR: u32 = 0xfeff0000;
 const PAGE_SIZE: u32 = 4096;
@@ -25,14 +31,14 @@ export function refine(ptr: u32, len: u32): u64 {
   const args = ctx.parseArgs(ptr, len);
   const payload = args.payload;
 
-  if (payload.length < 1) return ctx.respond(ERR_PARSE);
+  if (payload.length < 1) return ctx.respond(i64(LibraryError.Parse));
 
   const tag = payload.raw[0];
   const rest = BytesBlob.wrap(payload.raw.subarray(1));
 
   if (tag === 0) return handleDemo(ctx, rest);
   if (tag === 1) return handleAdmin(ctx, rest);
-  return ctx.respond(ERR_PARSE);
+  return ctx.respond(i64(LibraryError.Parse));
 }
 
 function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
@@ -41,26 +47,28 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const entrypoint = d.u32();
   const gas = d.u64();
   const callPayload = d.bytesVarLen();
-  if (d.isError) return ctx.respond(ERR_PARSE);
-  if (!d.isFinished()) return ctx.respond(ERR_PARSE);
+  if (d.isError) return ctx.respond(i64(LibraryError.Parse));
+  if (!d.isFinished()) return ctx.respond(i64(LibraryError.Parse));
 
   // Resolve name → LibraryEntry via storage
   const storage = ctx.serviceData();
   const stored = storage.read(libraryKeyFromBlob(name));
-  if (!stored.isSome) return ctx.respond(ERR_UNKNOWN_LIB);
+  if (!stored.isSome) return ctx.respond(i64(LibraryError.UnknownLib));
   const entryDecoder = Decoder.fromBlob(stored.val!);
   const entryR = LibraryEntryCodec.create().decode(entryDecoder);
-  if (entryR.isError || !entryDecoder.isFinished()) return ctx.respond(ERR_UNKNOWN_LIB);
+  if (entryR.isError || !entryDecoder.isFinished()) return ctx.respond(i64(LibraryError.UnknownLib));
   const entry = entryR.okay!;
 
-  // Fetch preimage (historical lookup — required in refine context)
-  const preimageOpt = ctx.preimages().historicalLookup(entry.hash);
-  if (!preimageOpt.isSome) return ctx.respond(ERR_PREIMAGE_MISS);
+  // Fetch preimage (historical lookup — required in refine context).
+  // Pre-size the helper's buffer to the known preimage length to avoid
+  // an initial short-read + auto-expand round trip.
+  const preimageOpt = ctx.preimages(entry.length).historicalLookup(entry.hash);
+  if (!preimageOpt.isSome) return ctx.respond(i64(LibraryError.PreimageMiss));
   const code = preimageOpt.val!;
 
   // Spawn inner machine
   const machineR = ctx.machine(code, entrypoint);
-  if (machineR.isError) return ctx.respond(ERR_INVALID_ENTRYPOINT);
+  if (machineR.isError) return ctx.respond(i64(LibraryError.InvalidEntryPoint));
   const m = machineR.okay;
 
   // Allocate RW pages at INPUT_ADDR to fit the payload (at least one page).
@@ -72,7 +80,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const pokeR = m.poke(INPUT_ADDR, callPayload);
   if (pokeR.isError) {
     m.expunge();
-    return ctx.respond(ERR_OOB);
+    return ctx.respond(i64(LibraryError.Oob));
   }
 
   // Build IO (SPI convention: r7 = input ptr, r8 = input len) and invoke.
@@ -86,7 +94,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
     const errEnc = Encoder.create();
     errEnc.u8(u8(outcome.reason));
     errEnc.u64(u64(outcome.r8));
-    return ctx.respond(ERR_INVOKE_FAILURE, errEnc.finishRaw());
+    return ctx.respond(i64(LibraryError.InvokeFailure), errEnc.finishRaw());
   }
 
   // Unpack r7 = ptrAndLen (low 32 = ptr, high 32 = len).
@@ -95,7 +103,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const outLen: u32 = u32(r7 >> 32);
   if (outLen > MAX_OUTPUT_LEN) {
     m.expunge();
-    return ctx.respond(ERR_OOB);
+    return ctx.respond(i64(LibraryError.Oob));
   }
 
   const outBuf = BytesBlob.zero(outLen);
@@ -103,7 +111,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
     const peekR = m.peek(outAddr, outBuf);
     if (peekR.isError) {
       m.expunge();
-      return ctx.respond(ERR_OOB);
+      return ctx.respond(i64(LibraryError.Oob));
     }
   }
   m.expunge();
@@ -114,8 +122,8 @@ function handleAdmin(ctx: RefineContext, rest: BytesBlob): u64 {
   const codec = AdminCommandCodec.create();
   const d = Decoder.fromBlob(rest.raw);
   const r = codec.decode(d);
-  if (r.isError) return ctx.respond(ERR_ADMIN_MALFORMED);
-  if (!d.isFinished()) return ctx.respond(ERR_ADMIN_MALFORMED);
+  if (r.isError) return ctx.respond(i64(LibraryError.AdminMalformed));
+  if (!d.isFinished()) return ctx.respond(i64(LibraryError.AdminMalformed));
 
   const enc = Encoder.create();
   codec.encode(r.okay!, enc);

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,4 +1,13 @@
-import { BytesBlob, Decoder, Encoder, ExitReason, InvokeIo, PageAccess, RefineContext } from "@fluffylabs/as-lan";
+import {
+  BytesBlob,
+  Decoder,
+  Encoder,
+  ExitReason,
+  InvokeIo,
+  Logger,
+  PageAccess,
+  RefineContext,
+} from "@fluffylabs/as-lan";
 import { AdminCommandCodec } from "./admin";
 import { LibraryEntryCodec, libraryKeyFromBlob } from "./storage";
 
@@ -26,18 +35,25 @@ const PAGE_SIZE: u32 = 4096;
 // a multi-GB allocation before peek() gets a chance to surface the error.
 const MAX_OUTPUT_LEN: u32 = 64 * 1024;
 
+const logger: Logger = Logger.create("library");
+
 export function refine(ptr: u32, len: u32): u64 {
   const ctx = RefineContext.create();
   const args = ctx.parseArgs(ptr, len);
   const payload = args.payload;
+  logger.info(`refine: service=${args.serviceId} payloadLen=${payload.length}`);
 
-  if (payload.length < 1) return ctx.respond(i64(LibraryError.Parse));
+  if (payload.length < 1) {
+    logger.warn("refine: empty payload");
+    return ctx.respond(i64(LibraryError.Parse));
+  }
 
   const tag = payload.raw[0];
   const rest = BytesBlob.wrap(payload.raw.subarray(1));
 
   if (tag === 0) return handleDemo(ctx, rest);
   if (tag === 1) return handleAdmin(ctx, rest);
+  logger.warn(`refine: unknown tag ${tag}`);
   return ctx.respond(i64(LibraryError.Parse));
 }
 
@@ -47,28 +63,49 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const entrypoint = d.u32();
   const gas = d.u64();
   const callPayload = d.bytesVarLen();
-  if (d.isError) return ctx.respond(i64(LibraryError.Parse));
-  if (!d.isFinished()) return ctx.respond(i64(LibraryError.Parse));
+  if (d.isError) {
+    logger.warn("refine demo: input decode failure");
+    return ctx.respond(i64(LibraryError.Parse));
+  }
+  if (!d.isFinished()) {
+    logger.warn("refine demo: input trailing bytes");
+    return ctx.respond(i64(LibraryError.Parse));
+  }
+  logger.info(`refine demo: name=${name.toString()} ep=${entrypoint} gas=${gas} payloadLen=${callPayload.length}`);
 
   // Resolve name → LibraryEntry via storage
   const storage = ctx.serviceData();
   const stored = storage.read(libraryKeyFromBlob(name));
-  if (!stored.isSome) return ctx.respond(i64(LibraryError.UnknownLib));
+  if (!stored.isSome) {
+    logger.warn(`refine demo: unknown library ${name.toString()}`);
+    return ctx.respond(i64(LibraryError.UnknownLib));
+  }
   const entryDecoder = Decoder.fromBlob(stored.val!);
   const entryR = LibraryEntryCodec.create().decode(entryDecoder);
-  if (entryR.isError || !entryDecoder.isFinished()) return ctx.respond(i64(LibraryError.UnknownLib));
+  if (entryR.isError || !entryDecoder.isFinished()) {
+    logger.warn(`refine demo: malformed stored entry for ${name.toString()}`);
+    return ctx.respond(i64(LibraryError.UnknownLib));
+  }
   const entry = entryR.okay!;
+  logger.debug(`refine demo: entry hash=${entry.hash.toString()} len=${entry.length}`);
 
   // Fetch preimage (historical lookup — required in refine context).
   // Pre-size the helper's buffer to the known preimage length to avoid
   // an initial short-read + auto-expand round trip.
   const preimageOpt = ctx.preimages(entry.length).historicalLookup(entry.hash);
-  if (!preimageOpt.isSome) return ctx.respond(i64(LibraryError.PreimageMiss));
+  if (!preimageOpt.isSome) {
+    logger.warn(`refine demo: preimage missing for ${name.toString()}`);
+    return ctx.respond(i64(LibraryError.PreimageMiss));
+  }
   const code = preimageOpt.val!;
+  logger.debug(`refine demo: preimage fetched ${code.length} bytes`);
 
   // Spawn inner machine
   const machineR = ctx.machine(code, entrypoint);
-  if (machineR.isError) return ctx.respond(i64(LibraryError.InvalidEntryPoint));
+  if (machineR.isError) {
+    logger.warn(`refine demo: invalid entrypoint ${entrypoint}`);
+    return ctx.respond(i64(LibraryError.InvalidEntryPoint));
+  }
   const m = machineR.okay;
 
   // Allocate RW pages at INPUT_ADDR to fit the payload (at least one page).
@@ -79,6 +116,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   // Poke payload into inner PVM memory.
   const pokeR = m.poke(INPUT_ADDR, callPayload);
   if (pokeR.isError) {
+    logger.warn("refine demo: poke OOB");
     m.expunge();
     return ctx.respond(i64(LibraryError.Oob));
   }
@@ -90,6 +128,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const outcome = m.invoke(io);
 
   if (outcome.reason !== ExitReason.Halt) {
+    logger.warn(`refine demo: invoke non-halt reason=${outcome.reason} r8=${outcome.r8}`);
     m.expunge();
     const errEnc = Encoder.create();
     errEnc.u8(u8(outcome.reason));
@@ -102,6 +141,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   const outAddr: u32 = u32(r7 & 0xffffffff);
   const outLen: u32 = u32(r7 >> 32);
   if (outLen > MAX_OUTPUT_LEN) {
+    logger.warn(`refine demo: output length ${outLen} exceeds cap ${MAX_OUTPUT_LEN}`);
     m.expunge();
     return ctx.respond(i64(LibraryError.Oob));
   }
@@ -110,11 +150,13 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
   if (outLen > 0) {
     const peekR = m.peek(outAddr, outBuf);
     if (peekR.isError) {
+      logger.warn(`refine demo: peek OOB addr=${outAddr} len=${outLen}`);
       m.expunge();
       return ctx.respond(i64(LibraryError.Oob));
     }
   }
   m.expunge();
+  logger.info(`refine demo: ok, output ${outLen} bytes`);
   return ctx.respond(0, outBuf.raw);
 }
 
@@ -122,8 +164,15 @@ function handleAdmin(ctx: RefineContext, rest: BytesBlob): u64 {
   const codec = AdminCommandCodec.create();
   const d = Decoder.fromBlob(rest.raw);
   const r = codec.decode(d);
-  if (r.isError) return ctx.respond(i64(LibraryError.AdminMalformed));
-  if (!d.isFinished()) return ctx.respond(i64(LibraryError.AdminMalformed));
+  if (r.isError) {
+    logger.warn("refine admin: decode failure");
+    return ctx.respond(i64(LibraryError.AdminMalformed));
+  }
+  if (!d.isFinished()) {
+    logger.warn("refine admin: trailing bytes");
+    return ctx.respond(i64(LibraryError.AdminMalformed));
+  }
+  logger.info(`refine admin: ok, cmd kind=${r.okay!.kind}`);
 
   const enc = Encoder.create();
   codec.encode(r.okay!, enc);

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -1,11 +1,6 @@
-import { AccumulateContext, RefineContext } from "@fluffylabs/as-lan";
+import { RefineContext } from "@fluffylabs/as-lan";
 
 export function refine(_ptr: u32, _len: u32): u64 {
   const ctx = RefineContext.create();
-  return ctx.respond(0);
-}
-
-export function accumulate(_ptr: u32, _len: u32): u64 {
-  const ctx = AccumulateContext.create();
   return ctx.respond(0);
 }

--- a/examples/library/assembly/storage.ts
+++ b/examples/library/assembly/storage.ts
@@ -47,3 +47,12 @@ export class LibraryEntryCodec implements TryDecode<LibraryEntry>, TryEncode<Lib
 export function libraryKey(name: string): Uint8Array {
   return BytesBlob.encodeAscii(`lib:${name}`).raw;
 }
+
+/** Build the storage key `"lib:<name>"` when `name` is already an ASCII byte blob. */
+export function libraryKeyFromBlob(name: BytesBlob): Uint8Array {
+  const prefix = BytesBlob.encodeAscii("lib:").raw;
+  const key = new Uint8Array(prefix.length + name.raw.length);
+  key.set(prefix, 0);
+  key.set(name.raw, prefix.length);
+  return key;
+}

--- a/examples/library/assembly/storage.ts
+++ b/examples/library/assembly/storage.ts
@@ -1,0 +1,49 @@
+import {
+  Bytes32,
+  BytesBlob,
+  DecodeError,
+  Decoder,
+  Encoder,
+  Result,
+  TryDecode,
+  TryEncode,
+} from "@fluffylabs/as-lan";
+
+/** Storage value for a library mapping: preimage hash + its length. */
+export class LibraryEntry {
+  static create(hash: Bytes32, length: u32): LibraryEntry {
+    return new LibraryEntry(hash, length);
+  }
+
+  private constructor(
+    public readonly hash: Bytes32,
+    public readonly length: u32,
+  ) {}
+}
+
+export class LibraryEntryCodec implements TryDecode<LibraryEntry>, TryEncode<LibraryEntry> {
+  static create(): LibraryEntryCodec {
+    return new LibraryEntryCodec();
+  }
+
+  private constructor() {}
+
+  encode(value: LibraryEntry, e: Encoder): void {
+    e.bytesFixLen(value.hash.bytes);
+    e.u32(value.length);
+  }
+
+  decode(d: Decoder): Result<LibraryEntry, DecodeError> {
+    const hashBytes = d.bytesFixLen(32);
+    if (d.isError) return Result.err<LibraryEntry, DecodeError>(DecodeError.MissingBytes);
+    const hash = Bytes32.wrapUnchecked(hashBytes.raw);
+    const length = d.u32();
+    if (d.isError) return Result.err<LibraryEntry, DecodeError>(DecodeError.MissingBytes);
+    return Result.ok<LibraryEntry, DecodeError>(LibraryEntry.create(hash, length));
+  }
+}
+
+/** Build the storage key `"lib:<name>"` as ASCII bytes. */
+export function libraryKey(name: string): Uint8Array {
+  return BytesBlob.encodeAscii(`lib:${name}`).raw;
+}

--- a/examples/library/assembly/storage.ts
+++ b/examples/library/assembly/storage.ts
@@ -1,13 +1,4 @@
-import {
-  Bytes32,
-  BytesBlob,
-  DecodeError,
-  Decoder,
-  Encoder,
-  Result,
-  TryDecode,
-  TryEncode,
-} from "@fluffylabs/as-lan";
+import { Bytes32, BytesBlob, DecodeError, Decoder, Encoder, Result, TryDecode, TryEncode } from "@fluffylabs/as-lan";
 
 /** Storage value for a library mapping: preimage hash + its length. */
 export class LibraryEntry {

--- a/examples/library/assembly/test-helpers.ts
+++ b/examples/library/assembly/test-helpers.ts
@@ -13,7 +13,7 @@ import {
   WorkExecResult,
   WorkExecResultKind,
 } from "@fluffylabs/as-lan";
-import { TestAccumulate, unpackResult } from "@fluffylabs/as-lan/test";
+import { unpackResult } from "@fluffylabs/as-lan/test";
 import { accumulate } from "./accumulate";
 import { refine } from "./refine";
 
@@ -22,13 +22,7 @@ const ZERO_HASH: Bytes32 = Bytes32.wrapUnchecked(new Uint8Array(32));
 /** Call refine with the given payload and decode the Response. */
 export function callRefine(payload: Uint8Array): Response {
   const ctx = RefineContext.create();
-  const args = RefineArgs.create(
-    0,
-    0,
-    42,
-    BytesBlob.wrap(payload),
-    Bytes32.wrapUnchecked(new Uint8Array(32)),
-  );
+  const args = RefineArgs.create(0, 0, 42, BytesBlob.wrap(payload), Bytes32.wrapUnchecked(new Uint8Array(32)));
   const enc = Encoder.create();
   ctx.refineArgs.encode(args, enc);
   const encoded = enc.finishRaw();

--- a/examples/library/assembly/test-helpers.ts
+++ b/examples/library/assembly/test-helpers.ts
@@ -1,14 +1,23 @@
 import {
+  AccumulateArgs,
+  AccumulateContext,
+  AccumulateItem,
   Bytes32,
   BytesBlob,
   Decoder,
   Encoder,
+  Operand,
   RefineArgs,
   RefineContext,
   Response,
+  WorkExecResult,
+  WorkExecResultKind,
 } from "@fluffylabs/as-lan";
-import { unpackResult } from "@fluffylabs/as-lan/test";
+import { TestAccumulate, unpackResult } from "@fluffylabs/as-lan/test";
+import { accumulate } from "./accumulate";
 import { refine } from "./refine";
+
+const ZERO_HASH: Bytes32 = Bytes32.wrapUnchecked(new Uint8Array(32));
 
 /** Call refine with the given payload and decode the Response. */
 export function callRefine(payload: Uint8Array): Response {
@@ -27,4 +36,33 @@ export function callRefine(payload: Uint8Array): Response {
   buf.set(encoded);
   const raw = unpackResult(refine(u32(buf.dataStart), buf.byteLength));
   return ctx.response.decode(Decoder.fromBlob(raw)).okay!;
+}
+
+/** Build an operand whose okBlob is the given admin command bytes. */
+export function buildAdminOperand(bytes: Uint8Array): Uint8Array {
+  const ctx = AccumulateContext.create();
+  const op = Operand.create(
+    ZERO_HASH,
+    ZERO_HASH,
+    ZERO_HASH,
+    ZERO_HASH,
+    100000,
+    WorkExecResult.create(WorkExecResultKind.Ok, BytesBlob.wrap(bytes)),
+    BytesBlob.empty(),
+  );
+  const enc = Encoder.create();
+  ctx.accumulateItem.encode(AccumulateItem.fromOperand(op), enc);
+  return enc.finishRaw();
+}
+
+/** Run accumulate with operands pre-seeded via TestAccumulate.setItem. */
+export function callAccumulate(argsLength: u32): u64 {
+  const ctx = AccumulateContext.create();
+  const args = AccumulateArgs.create(7, 42, argsLength);
+  const enc = Encoder.create();
+  ctx.accumulateArgs.encode(args, enc);
+  const encoded = enc.finishRaw();
+  const buf = new Uint8Array(encoded.length);
+  buf.set(encoded);
+  return accumulate(u32(buf.dataStart), buf.byteLength);
 }

--- a/examples/library/assembly/test-helpers.ts
+++ b/examples/library/assembly/test-helpers.ts
@@ -1,0 +1,30 @@
+import {
+  Bytes32,
+  BytesBlob,
+  Decoder,
+  Encoder,
+  RefineArgs,
+  RefineContext,
+  Response,
+} from "@fluffylabs/as-lan";
+import { unpackResult } from "@fluffylabs/as-lan/test";
+import { refine } from "./refine";
+
+/** Call refine with the given payload and decode the Response. */
+export function callRefine(payload: Uint8Array): Response {
+  const ctx = RefineContext.create();
+  const args = RefineArgs.create(
+    0,
+    0,
+    42,
+    BytesBlob.wrap(payload),
+    Bytes32.wrapUnchecked(new Uint8Array(32)),
+  );
+  const enc = Encoder.create();
+  ctx.refineArgs.encode(args, enc);
+  const encoded = enc.finishRaw();
+  const buf = new Uint8Array(encoded.length);
+  buf.set(encoded);
+  const raw = unpackResult(refine(u32(buf.dataStart), buf.byteLength));
+  return ctx.response.decode(Decoder.fromBlob(raw)).okay!;
+}

--- a/examples/library/assembly/test-run.ts
+++ b/examples/library/assembly/test-run.ts
@@ -1,0 +1,5 @@
+import { runTestSuites } from "@fluffylabs/as-lan/test";
+
+export function runAllTests(): void {
+  runTestSuites([]);
+}

--- a/examples/library/assembly/test-run.ts
+++ b/examples/library/assembly/test-run.ts
@@ -1,5 +1,6 @@
-import { runTestSuites } from "@fluffylabs/as-lan/test";
+import { runTestSuites, TestSuite } from "@fluffylabs/as-lan/test";
+import * as refineTests from "./refine.test";
 
 export function runAllTests(): void {
-  runTestSuites([]);
+  runTestSuites([TestSuite.create(refineTests.TESTS, "refine.test.ts")]);
 }

--- a/examples/library/assembly/test-run.ts
+++ b/examples/library/assembly/test-run.ts
@@ -1,6 +1,10 @@
 import { runTestSuites, TestSuite } from "@fluffylabs/as-lan/test";
+import * as accumulateTests from "./accumulate.test";
 import * as refineTests from "./refine.test";
 
 export function runAllTests(): void {
-  runTestSuites([TestSuite.create(refineTests.TESTS, "refine.test.ts")]);
+  runTestSuites([
+    TestSuite.create(refineTests.TESTS, "refine.test.ts"),
+    TestSuite.create(accumulateTests.TESTS, "accumulate.test.ts"),
+  ]);
 }

--- a/examples/library/assembly/tsconfig.json
+++ b/examples/library/assembly/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "assemblyscript/std/assembly.json",
+  "include": ["./**/*.ts"],
+  "compilerOptions": {
+    "paths": {
+      "@fluffylabs/as-lan": ["../../../sdk/index.ts"],
+      "@fluffylabs/as-lan/*": ["../../../sdk/*"]
+    }
+  }
+}

--- a/examples/library/bin/test.js
+++ b/examples/library/bin/test.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { setMemory } from "ecalli";
+import { memory, runAllTests } from "../build/test.js";
+
+setMemory(memory);
+runAllTests();

--- a/examples/library/package-lock.json
+++ b/examples/library/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "name": "@fluffylabs/as-lan-library-example",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@fluffylabs/as-lan-library-example",
+      "version": "0.0.1",
+      "license": "MPL-2.0",
+      "devDependencies": {
+        "@fluffylabs/as-lan": "file:../../sdk",
+        "assemblyscript": "^0.28.10",
+        "ecalli": "file:../../sdk-ecalli-mocks"
+      }
+    },
+    "../../sdk": {
+      "name": "@fluffylabs/as-lan",
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "assemblyscript": "^0.28.10",
+        "ecalli": "file:../sdk-ecalli-mocks"
+      }
+    },
+    "../../sdk-ecalli-mocks": {
+      "name": "@fluffylabs/sdk-ecalli-mocks",
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "typescript": "^6.0.0"
+      }
+    },
+    "node_modules/@fluffylabs/as-lan": {
+      "resolved": "../../sdk",
+      "link": true
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.28.14",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.28.14.tgz",
+      "integrity": "sha512-YcFSCNhjvHdvjjqdfc1PyiA60AYalmDH2FDMF9LNmYJjoKf8c826xw3zkOD83PGoyz8RNH9KDt8FYMtkIOJNPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "binaryen": "123.0.0-nightly.20250530",
+        "long": "^5.2.4"
+      },
+      "bin": {
+        "asc": "bin/asc.js",
+        "asinit": "bin/asinit.js"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "123.0.0-nightly.20250530",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-123.0.0-nightly.20250530.tgz",
+      "integrity": "sha512-d1zPHBN5YlOd3Ff+OUxvVExuFeh8heSnqe+X3bjItFxGLvn4VGBKmrvv7pgy/cRhrIUGuPW138iaWfDhwjyDqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-as": "bin/wasm-as",
+        "wasm-ctor-eval": "bin/wasm-ctor-eval",
+        "wasm-dis": "bin/wasm-dis",
+        "wasm-merge": "bin/wasm-merge",
+        "wasm-metadce": "bin/wasm-metadce",
+        "wasm-opt": "bin/wasm-opt",
+        "wasm-reduce": "bin/wasm-reduce",
+        "wasm-shell": "bin/wasm-shell",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
+    "node_modules/ecalli": {
+      "resolved": "../../sdk-ecalli-mocks",
+      "link": true
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/examples/library/package.json
+++ b/examples/library/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@fluffylabs/as-lan-library-example",
+  "version": "0.0.1",
+  "description": "Library service example (reusable PVM blobs via preimages) using as-lan SDK",
+  "type": "module",
+  "scripts": {
+    "asbuild:debug": "asc assembly/index.ts --target debug --runtime=stub",
+    "asbuild:release": "asc assembly/index.ts --target release --runtime=stub",
+    "asbuild:test": "asc assembly/test-run.ts --target test",
+    "asbuild": "npm run asbuild:debug && npm run asbuild:release",
+    "pvm": "wasm-pvm compile build/release.wasm -o build/release.pvm --adapter ../../pvm-adapter.wat",
+    "build": "npm run asbuild && npm run pvm",
+    "test": "npm run asbuild:test && node ./bin/test.js"
+  },
+  "author": "Fluffy Labs",
+  "license": "MPL-2.0",
+  "devDependencies": {
+    "@fluffylabs/as-lan": "file:../../sdk",
+    "assemblyscript": "^0.28.10",
+    "ecalli": "file:../../sdk-ecalli-mocks"
+  },
+  "exports": {
+    ".": {
+      "import": "./build/release.js",
+      "types": "./build/release.d.ts"
+    }
+  }
+}

--- a/sdk-ecalli-mocks/src/accumulate/index.ts
+++ b/sdk-ecalli-mocks/src/accumulate/index.ts
@@ -20,6 +20,7 @@ export { transfer, setTransferResult, resetTransfer } from "./transfer.js";
 export {
   query, solicit, forget, yield_result, provide,
   setQueryResult, setSolicitResult, setForgetResult, setProvideResult, resetPreimages,
+  getSolicitCount, getForgetCount, getProvideCount, resetPreimageCounters,
 } from "./preimages.js";
 
 import { resetPrivileged } from "./privileged.js";

--- a/sdk-ecalli-mocks/src/accumulate/preimages.ts
+++ b/sdk-ecalli-mocks/src/accumulate/preimages.ts
@@ -13,6 +13,10 @@ let solicitResult: bigint = 0n; // OK
 let forgetResult: bigint = 0n; // OK
 let provideResult: bigint = 0n; // OK
 
+let solicitCount = 0;
+let forgetCount = 0;
+let provideCount = 0;
+
 /** Configure the query ecalli return values (r7, r8). */
 export function setQueryResult(r7: bigint, r8: bigint): void {
   queryR7 = r7;
@@ -34,12 +38,33 @@ export function setProvideResult(result: bigint): void {
   provideResult = result;
 }
 
+export function getSolicitCount(): bigint {
+  return BigInt(solicitCount);
+}
+
+export function getForgetCount(): bigint {
+  return BigInt(forgetCount);
+}
+
+export function getProvideCount(): bigint {
+  return BigInt(provideCount);
+}
+
+export function resetPreimageCounters(): void {
+  solicitCount = 0;
+  forgetCount = 0;
+  provideCount = 0;
+}
+
 export function resetPreimages(): void {
   queryR7 = -1n;
   queryR8 = 0n;
   solicitResult = 0n;
   forgetResult = 0n;
   provideResult = 0n;
+  solicitCount = 0;
+  forgetCount = 0;
+  provideCount = 0;
 }
 
 // ─── Ecalli stubs ────────────────────────────────────────────────────────
@@ -59,6 +84,7 @@ export function solicit(
   _hash_ptr: number,
   _length: number,
 ): bigint {
+  solicitCount++;
   return solicitResult;
 }
 
@@ -67,6 +93,7 @@ export function forget(
   _hash_ptr: number,
   _length: number,
 ): bigint {
+  forgetCount++;
   return forgetResult;
 }
 
@@ -83,5 +110,6 @@ export function provide(
   _preimage_ptr: number,
   _preimage_len: number,
 ): bigint {
+  provideCount++;
   return provideResult;
 }

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -51,6 +51,7 @@ export { transfer, setTransferResult, resetTransfer } from "./accumulate/index.j
 export {
   query, solicit, forget, yield_result, provide,
   setQueryResult, setSolicitResult, setForgetResult, setProvideResult,
+  getSolicitCount, getForgetCount, getProvideCount, resetPreimageCounters,
 } from "./accumulate/index.js";
 
 // Reset

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -28,7 +28,8 @@ export {
 export { export_segment as export, setExportSegmentResult } from "./refine/index.js";
 export {
   machine, peek, poke, pages, invoke, expunge,
-  setMachineResult, setPeekResult, setPokeResult, setPagesResult, setInvokeResult, setExpungeResult,
+  setMachineResult, setPeekResult, setPokeResult, setPagesResult, setInvokeResult, setInvokeIoR7,
+  setExpungeResult,
 } from "./refine/index.js";
 
 // Accumulate ecalli stubs (14-26)

--- a/sdk-ecalli-mocks/src/index.ts
+++ b/sdk-ecalli-mocks/src/index.ts
@@ -28,8 +28,8 @@ export {
 export { export_segment as export, setExportSegmentResult } from "./refine/index.js";
 export {
   machine, peek, poke, pages, invoke, expunge,
-  setMachineResult, setPeekResult, setPokeResult, setPagesResult, setInvokeResult, setInvokeIoR7,
-  setExpungeResult,
+  setMachineResult, setPeekResult, setPeekData, setPokeResult, setPagesResult, setInvokeResult,
+  setInvokeIoR7, setExpungeResult,
 } from "./refine/index.js";
 
 // Accumulate ecalli stubs (14-26)

--- a/sdk-ecalli-mocks/src/refine/index.ts
+++ b/sdk-ecalli-mocks/src/refine/index.ts
@@ -7,7 +7,8 @@ export {
 export { export_segment, setExportSegmentResult, resetSegments } from "./segments.js";
 export {
   machine, peek, poke, pages, invoke, expunge, resetMachines,
-  setMachineResult, setPeekResult, setPokeResult, setPagesResult, setInvokeResult, setExpungeResult,
+  setMachineResult, setPeekResult, setPokeResult, setPagesResult, setInvokeResult, setInvokeIoR7,
+  setExpungeResult,
 } from "./machines.js";
 
 import { resetHistoricalLookup } from "./lookup.js";

--- a/sdk-ecalli-mocks/src/refine/index.ts
+++ b/sdk-ecalli-mocks/src/refine/index.ts
@@ -7,8 +7,8 @@ export {
 export { export_segment, setExportSegmentResult, resetSegments } from "./segments.js";
 export {
   machine, peek, poke, pages, invoke, expunge, resetMachines,
-  setMachineResult, setPeekResult, setPokeResult, setPagesResult, setInvokeResult, setInvokeIoR7,
-  setExpungeResult,
+  setMachineResult, setPeekResult, setPeekData, setPokeResult, setPagesResult, setInvokeResult,
+  setInvokeIoR7, setExpungeResult,
 } from "./machines.js";
 
 import { resetHistoricalLookup } from "./lookup.js";

--- a/sdk-ecalli-mocks/src/refine/machines.ts
+++ b/sdk-ecalli-mocks/src/refine/machines.ts
@@ -12,6 +12,7 @@ let pokeResult: bigint | null = null;
 let pagesResult: bigint | null = null;
 let invokeResult: bigint | null = null;
 let invokeR8: bigint = 0n;
+let invokeIoR7: bigint | null = null;
 let expungeResult: bigint | null = null;
 
 /** Ecalli 8: Create inner PVM machine. */
@@ -60,10 +61,14 @@ export function pages(
 /** Ecalli 12: Invoke inner machine — returns HALT (0), writes r8. */
 export function invoke(
   _machine_id: number,
-  _io_ptr: number,
+  io_ptr: number,
   out_r8: number,
 ): bigint {
   writeI64(out_r8, invokeR8);
+  if (invokeIoR7 !== null) {
+    // InvokeIo layout: [gas(8), r0(8), r1(8), ..., r12(8)]. r7 is at offset 8 + 7*8 = 64.
+    writeI64(io_ptr + 64, invokeIoR7);
+  }
   if (invokeResult !== null) return invokeResult;
   return 0n; // HALT
 }
@@ -99,6 +104,10 @@ export function setInvokeResult(result: bigint, r8: bigint = 0n): void {
   invokeR8 = r8;
 }
 
+export function setInvokeIoR7(value: bigint): void {
+  invokeIoR7 = value;
+}
+
 export function setExpungeResult(result: bigint): void {
   expungeResult = result;
 }
@@ -111,5 +120,6 @@ export function resetMachines(): void {
   pagesResult = null;
   invokeResult = null;
   invokeR8 = 0n;
+  invokeIoR7 = null;
   expungeResult = null;
 }

--- a/sdk-ecalli-mocks/src/refine/machines.ts
+++ b/sdk-ecalli-mocks/src/refine/machines.ts
@@ -3,11 +3,12 @@
 // machine (8), peek (9), poke (10), pages (11), invoke (12), expunge (13)
 // are tightly coupled — all operate on inner machines created via machine().
 
-import { writeI64 } from "../memory.js";
+import { readBytes, writeI64, writeToMem } from "../memory.js";
 
 let machineCounter = 0;
 let machineResult: bigint | null = null;
 let peekResult: bigint | null = null;
+let peekData: Uint8Array | null = null;
 let pokeResult: bigint | null = null;
 let pagesResult: bigint | null = null;
 let invokeResult: bigint | null = null;
@@ -28,10 +29,13 @@ export function machine(
 /** Ecalli 9: Peek inner machine memory — returns OK. */
 export function peek(
   _machine_id: number,
-  _dest_ptr: number,
+  dest_ptr: number,
   _source: number,
-  _length: number,
+  length: number,
 ): bigint {
+  if (peekData !== null) {
+    writeToMem(dest_ptr, peekData, 0, length);
+  }
   if (peekResult !== null) return peekResult;
   return 0n; // OK
 }
@@ -91,6 +95,11 @@ export function setPeekResult(result: bigint): void {
   peekResult = result;
 }
 
+/** Configure peek() to copy these bytes into dest_ptr. AS calls via (ptr, len). */
+export function setPeekData(ptr: number, len: number): void {
+  peekData = readBytes(ptr, len);
+}
+
 export function setPokeResult(result: bigint): void {
   pokeResult = result;
 }
@@ -116,6 +125,7 @@ export function resetMachines(): void {
   machineCounter = 0;
   machineResult = null;
   peekResult = null;
+  peekData = null;
   pokeResult = null;
   pagesResult = null;
   invokeResult = null;

--- a/sdk-ecalli-mocks/src/refine/machines.ts
+++ b/sdk-ecalli-mocks/src/refine/machines.ts
@@ -33,6 +33,9 @@ export function peek(
   _source: number,
   length: number,
 ): bigint {
+  // Skip memory write when the mock is configured with an error sentinel —
+  // a real host returning OOB/WHO would not touch the destination buffer.
+  if (peekResult !== null && peekResult < 0n) return peekResult;
   if (peekData !== null) {
     writeToMem(dest_ptr, peekData, 0, length);
   }

--- a/sdk/jam/account-info.test.ts
+++ b/sdk/jam/account-info.test.ts
@@ -193,7 +193,7 @@ export const TESTS: Test[] = [
     const svc = CurrentServiceData.create();
     const key = ByteBuf.create(32).strAscii("newkey").finish();
     const val = BytesBlob.parseBlob("0x010203").okay!;
-    const result = svc.write(key, val.raw);
+    const result = svc.write(key, val);
     a.isEqual(result.isOkay, true, "should be ok");
     a.isEqual(result.okay!.isSome, false, "no previous value");
     return a;
@@ -211,11 +211,11 @@ export const TESTS: Test[] = [
     val2.raw.fill(0xbb);
 
     // First write — no previous value
-    svc.write(key, val1.raw);
+    svc.write(key, val1);
 
     // Second write — should return previous length (5)
     const key2 = ByteBuf.create(32).strAscii("overkey").finish();
-    const result = svc.write(key2, val2.raw);
+    const result = svc.write(key2, val2);
     a.isEqual(result.isOkay, true, "should be ok");
     a.isEqual(result.okay!.isSome, true, "has previous value");
     a.isEqual(result.okay!.val, 5, "previous length");
@@ -230,7 +230,7 @@ export const TESTS: Test[] = [
     const key = ByteBuf.create(32).strAscii("rtkey").finish();
     const val = BytesBlob.parseBlob("0xcafebabe").okay!;
 
-    svc.write(key, val.raw);
+    svc.write(key, val);
 
     const key2 = ByteBuf.create(32).strAscii("rtkey").finish();
     const result = svc.read(key2);

--- a/sdk/jam/service-data.ts
+++ b/sdk/jam/service-data.ts
@@ -5,6 +5,7 @@
  * - {@link CurrentServiceData} — adds write access for the current service.
  */
 
+import { BytesBlob } from "../core/bytes";
 import { Decoder } from "../core/codec/decode";
 import { panic } from "../core/panic";
 import { Optional, OptionalN, Result } from "../core/result";
@@ -88,10 +89,10 @@ export class CurrentServiceData extends ServiceData {
    *
    * Returns the previous value's length wrapped in Optional (None if no prior value existed).
    * Fails with WriteError.Full if the storage quota is exceeded.
-   * Pass an empty value (length 0) to delete the entry.
+   * Pass `BytesBlob.empty()` to delete the entry.
    */
-  write(key: Uint8Array, value: Uint8Array): Result<OptionalN<u64>, WriteError> {
-    const result = write(u32(key.dataStart), key.length, u32(value.dataStart), value.length);
+  write(key: Uint8Array, value: BytesBlob): Result<OptionalN<u64>, WriteError> {
+    const result = write(u32(key.dataStart), key.length, value.ptr(), value.length);
     if (result === EcalliResult.FULL) return Result.err<OptionalN<u64>, WriteError>(WriteError.Full);
     if (result === EcalliResult.NONE) return Result.ok<OptionalN<u64>, WriteError>(OptionalN.none<u64>());
     return Result.ok<OptionalN<u64>, WriteError>(OptionalN.some<u64>(u64(result)));

--- a/sdk/test/test-ecalli/machines.ts
+++ b/sdk/test/test-ecalli/machines.ts
@@ -7,6 +7,10 @@ declare function _setMachineResult(result: i64): void;
 declare function _setPeekResult(result: i64): void;
 
 // @ts-expect-error: decorator
+@external("ecalli", "setPeekData")
+declare function _setPeekData(ptr: u32, len: u32): void;
+
+// @ts-expect-error: decorator
 @external("ecalli", "setPokeResult")
 declare function _setPokeResult(result: i64): void;
 
@@ -34,6 +38,10 @@ export class TestMachine {
 
   static setPeekResult(result: i64): void {
     _setPeekResult(result);
+  }
+
+  static setPeekData(data: Uint8Array): void {
+    _setPeekData(u32(data.dataStart), data.length);
   }
 
   static setPokeResult(result: i64): void {

--- a/sdk/test/test-ecalli/machines.ts
+++ b/sdk/test/test-ecalli/machines.ts
@@ -19,6 +19,10 @@ declare function _setPagesResult(result: i64): void;
 declare function _setInvokeResult(result: i64, r8: i64): void;
 
 // @ts-expect-error: decorator
+@external("ecalli", "setInvokeIoR7")
+declare function _setInvokeIoR7(value: i64): void;
+
+// @ts-expect-error: decorator
 @external("ecalli", "setExpungeResult")
 declare function _setExpungeResult(result: i64): void;
 
@@ -42,6 +46,10 @@ export class TestMachine {
 
   static setInvokeResult(result: i64, r8: i64 = 0): void {
     _setInvokeResult(result, r8);
+  }
+
+  static setInvokeIoR7(value: i64): void {
+    _setInvokeIoR7(value);
   }
 
   static setExpungeResult(result: i64): void {

--- a/sdk/test/test-ecalli/preimages.ts
+++ b/sdk/test/test-ecalli/preimages.ts
@@ -14,6 +14,22 @@ declare function _setForgetResult(result: i64): void;
 @external("ecalli", "setProvideResult")
 declare function _setProvideResult(result: i64): void;
 
+// @ts-expect-error: decorator
+@external("ecalli", "getSolicitCount")
+declare function _getSolicitCount(): i64;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getForgetCount")
+declare function _getForgetCount(): i64;
+
+// @ts-expect-error: decorator
+@external("ecalli", "getProvideCount")
+declare function _getProvideCount(): i64;
+
+// @ts-expect-error: decorator
+@external("ecalli", "resetPreimageCounters")
+declare function _resetPreimageCounters(): void;
+
 /** Configure accumulate preimage ecalli stubs. */
 export class TestPreimages {
   /**
@@ -39,5 +55,21 @@ export class TestPreimages {
   /** Configure provide() return value (0 = OK, -4 = WHO, -9 = HUH). */
   static setProvideResult(result: i64): void {
     _setProvideResult(result);
+  }
+
+  static getSolicitCount(): i64 {
+    return _getSolicitCount();
+  }
+
+  static getForgetCount(): i64 {
+    return _getForgetCount();
+  }
+
+  static getProvideCount(): i64 {
+    return _getProvideCount();
+  }
+
+  static resetCounters(): void {
+    _resetPreimageCounters();
   }
 }


### PR DESCRIPTION
## Summary

New `examples/library/` example service that hosts reusable verification PVM blobs (ed25519, blake2b, …) as preimages, resolved by name via storage, and invokable via the inner-PVM `Machine` interface. The service's own `refine` is the canonical demo of the Machine lifecycle (create → pages → poke → invoke → peek → expunge) using the SPI calling convention.

**Design:** `docs/superpowers/specs/2026-04-20-library-service-design.md` (gitignored — included in the branch commits for reviewer context only; remove from working copy before merge if you want it gone).

## What's in it

- **`examples/library/`** — new example with `refine` + `accumulate` entry points.
  - **Refine** tag-dispatches: `tag=0` → demo (resolve name → preimage → inner PVM), `tag=1` → admin (validate + canonical re-encode; forwards bytes as operand to accumulate).
  - **Accumulate** iterates operands, decodes admin commands, dispatches to `ServiceData.write` / `AccumulatePreimages.solicit/forget/provide`.
  - **`AdminCommand`** tagged union + codec: `SetMapping`, `RemoveMapping`, `Solicit`, `Forget`, `Provide`.
  - **`LibraryEntry`** storage value: `(hash: Bytes32, length: u32)` keyed at `"lib:<name>"`.
- **SDK mock additions** (`sdk-ecalli-mocks/` + `sdk/test/test-ecalli/`):
  - `setInvokeIoR7(value)` — mock writes r7 into the `InvokeIo` buffer after invoke (needed to simulate halt ABI).
  - `setPeekData(bytes)` — mock writes configured bytes into the peek destination.
  - Call counters on accumulate preimage ecallis: `getSolicitCount`, `getForgetCount`, `getProvideCount`, `resetPreimageCounters`.
- **Docs:**
  - `docs/src/sdk-api/refine.md` gains a "Calling convention for library-style inner PVMs" subsection documenting `INPUT_ADDR = 0xFEFF0000`, r7/r8 on entry, r7 packed ptrAndLen on exit.
  - `CLAUDE.md` project-structure block describes the new example layout.
- **Error codes** use `-100..-106` to avoid colliding with `EcalliResult` sentinels that share the `Response.result` field.

## Known open points (intentionally out of scope)

- `fixtures/halt.pvm` is an empty placeholder. Tests mock the Machine layer end-to-end; no real PVM bytes exist yet. Real ed25519 / blake2b blobs land in a follow-up.
- `INPUT_ADDR = 0xFEFF0000` follows the stated SPI convention but is not cross-referenced against a canonical JAM/GP doc in this branch. Worth confirming before real PVM code arrives (mocks would not catch a wrong address).
- A separate library-*consumer* example (a service that looks up a library by hash and invokes it across service boundaries) is tracked as a follow-up issue.

## Test plan

- [x] `npm run qa` — biome clean
- [x] `npm run build` — mocks + SDK + all examples (incl. new library example)
- [x] `npm test` — 29/29 tests green (17 refine + 8 accumulate)

Test coverage per error branch:

- refine admin: valid round-trip per verb (5), malformed bytes → -105, unknown tag → -106, empty payload → -106
- refine demo: happy path, unknown name → -100, malformed stored entry → -100, preimage miss → -101, invalid entrypoint → -102, invoke Panic → -103 (body = u8 reason + u64 r8), peek OOB → -104
- accumulate: each admin verb, malformed operand skip, multi-operand ordering, solicit/forget/provide dispatch via call counters

🤖 Generated with [Claude Code](https://claude.com/claude-code)