### PR TITLE
sdk: unify ServiceData.read/write to use BytesBlob

### DIFF
--- a/docs/src/sdk-api/common.md
+++ b/docs/src/sdk-api/common.md
@@ -19,8 +19,8 @@ High-level wrappers for service storage (`read`/`write`) and account info (`info
 // Read/write access to the current service (preferred)
 const storage = ctx.serviceData();
 const info = storage.info();                  // Optional<AccountInfo>
-const val = storage.read(key);               // Optional<Uint8Array>
-const result = storage.write(key, value);    // value: BytesBlob → Result<OptionalN<u64>, WriteError>
+const val = storage.read(key);               // key: BytesBlob → Optional<BytesBlob>
+const result = storage.write(key, value);    // key/value: BytesBlob → Result<OptionalN<u64>, WriteError>
 
 // Read-only access to another service by ID
 const other = ServiceData.create(42);

--- a/docs/src/sdk-api/utilities.md
+++ b/docs/src/sdk-api/utilities.md
@@ -79,6 +79,7 @@ Builder methods (all return `ByteBuf` for chaining):
 
 Terminal methods:
 - **`.finish()`** — copy buffer into a new `Uint8Array` and reset
+- **`.finishBlob()`** — copy buffer into a new `BytesBlob` and reset
 - **`.reset()`** — discard contents without producing output
 
 The buffer is heap-allocated at a fixed capacity; writes beyond the capacity

--- a/examples/library/assembly/accumulate.test.ts
+++ b/examples/library/assembly/accumulate.test.ts
@@ -30,7 +30,7 @@ export const TESTS: Test[] = [
     hash.raw[0] = 0x11;
     const entryEnc = Encoder.create();
     LibraryEntryCodec.create().encode(LibraryEntry.create(hash, 32), entryEnc);
-    TestStorage.set(BytesBlob.wrap(libraryKey("blake2b")), BytesBlob.wrap(entryEnc.finishRaw()));
+    TestStorage.set(libraryKey("blake2b"), BytesBlob.wrap(entryEnc.finishRaw()));
 
     const cmd = AdminCommand.removeMapping(BytesBlob.encodeAscii("blake2b"));
     TestAccumulate.setItem(0, buildAdminOperand(encodeAdmin(cmd)));
@@ -91,7 +91,7 @@ export const TESTS: Test[] = [
     const assert = Assert.create();
     // Set then Remove → storage ends empty. Reversed order would leave the
     // entry present. Observable side-effect therefore depends on ordering.
-    TestStorage.set(BytesBlob.wrap(libraryKey("ordered")), null);
+    TestStorage.set(libraryKey("ordered"), null);
     const hash = Bytes32.zero();
     hash.raw[0] = 0x55;
     TestAccumulate.setItem(
@@ -111,7 +111,7 @@ export const TESTS: Test[] = [
 
   test("accumulate: SetMapping writes LibraryEntry to storage", () => {
     const assert = Assert.create();
-    TestStorage.set(BytesBlob.wrap(libraryKey("ed25519")), null);
+    TestStorage.set(libraryKey("ed25519"), null);
 
     const hash = Bytes32.zero();
     hash.raw[0] = 0xab;
@@ -125,7 +125,7 @@ export const TESTS: Test[] = [
       assert.fail("entry not written");
       return assert;
     }
-    const decoded = LibraryEntryCodec.create().decode(Decoder.fromBlob(got.val!)).okay!;
+    const decoded = LibraryEntryCodec.create().decode(Decoder.fromBlob(got.val!.raw)).okay!;
     assert.isEqual(decoded.hash.raw[0], 0xab, "hash");
     assert.isEqual(decoded.length, 8192, "length");
     return assert;

--- a/examples/library/assembly/refine.test.ts
+++ b/examples/library/assembly/refine.test.ts
@@ -20,7 +20,7 @@ function seedLibraryMapping(name: string, hashByte0: u8, length: u32): void {
   const e = LibraryEntry.create(h, length);
   const enc = Encoder.create();
   LibraryEntryCodec.create().encode(e, enc);
-  TestStorage.set(BytesBlob.wrap(libraryKey(name)), BytesBlob.wrap(enc.finishRaw()));
+  TestStorage.set(libraryKey(name), BytesBlob.wrap(enc.finishRaw()));
 }
 
 export const TESTS: Test[] = [
@@ -63,7 +63,7 @@ export const TESTS: Test[] = [
     const assert = Assert.create();
     const key = libraryKey("ed25519");
     const expected = BytesBlob.encodeAscii("lib:ed25519");
-    assert.isEqualBytes(BytesBlob.wrap(key), expected, "key");
+    assert.isEqualBytes(key, expected, "key");
     return assert;
   }),
 
@@ -226,7 +226,7 @@ export const TESTS: Test[] = [
 
   test("refine demo: unknown library name returns -100", () => {
     const assert = Assert.create();
-    TestStorage.set(BytesBlob.wrap(libraryKey("missing")), null);
+    TestStorage.set(libraryKey("missing"), null);
 
     const input = buildDemoInput("missing", 0, 1000, BytesBlob.empty());
     const resp = callRefine(input);
@@ -237,7 +237,7 @@ export const TESTS: Test[] = [
   test("refine demo: malformed stored entry returns -100", () => {
     const assert = Assert.create();
     // Store a value that is too short to decode a LibraryEntry (hash+length = 36 bytes).
-    TestStorage.set(BytesBlob.wrap(libraryKey("corrupt")), BytesBlob.parseBlob("0xdead").okay!);
+    TestStorage.set(libraryKey("corrupt"), BytesBlob.parseBlob("0xdead").okay!);
 
     const input = buildDemoInput("corrupt", 0, 1000, BytesBlob.empty());
     const resp = callRefine(input);
@@ -334,7 +334,7 @@ export const TESTS: Test[] = [
     const enc = Encoder.create();
     LibraryEntryCodec.create().encode(entry, enc);
     enc.u8(0xff); // trailing junk
-    TestStorage.set(BytesBlob.wrap(libraryKey("trail")), BytesBlob.wrap(enc.finishRaw()));
+    TestStorage.set(libraryKey("trail"), BytesBlob.wrap(enc.finishRaw()));
 
     const resp = callRefine(buildDemoInput("trail", 0, 1000, BytesBlob.empty()));
     assert.isEqual(resp.result, -100, "trailing bytes in stored entry rejected");

--- a/examples/library/assembly/refine.ts
+++ b/examples/library/assembly/refine.ts
@@ -80,7 +80,7 @@ function handleDemo(ctx: RefineContext, rest: BytesBlob): u64 {
     logger.warn(`refine demo: unknown library ${name.toString()}`);
     return ctx.respond(i64(LibraryError.UnknownLib));
   }
-  const entryDecoder = Decoder.fromBlob(stored.val!);
+  const entryDecoder = Decoder.fromBlob(stored.val!.raw);
   const entryR = LibraryEntryCodec.create().decode(entryDecoder);
   if (entryR.isError || !entryDecoder.isFinished()) {
     logger.warn(`refine demo: malformed stored entry for ${name.toString()}`);

--- a/examples/library/assembly/storage.ts
+++ b/examples/library/assembly/storage.ts
@@ -35,15 +35,15 @@ export class LibraryEntryCodec implements TryDecode<LibraryEntry>, TryEncode<Lib
 }
 
 /** Build the storage key `"lib:<name>"` as ASCII bytes. */
-export function libraryKey(name: string): Uint8Array {
-  return BytesBlob.encodeAscii(`lib:${name}`).raw;
+export function libraryKey(name: string): BytesBlob {
+  return BytesBlob.encodeAscii(`lib:${name}`);
 }
 
 /** Build the storage key `"lib:<name>"` when `name` is already an ASCII byte blob. */
-export function libraryKeyFromBlob(name: BytesBlob): Uint8Array {
+export function libraryKeyFromBlob(name: BytesBlob): BytesBlob {
   const prefix = BytesBlob.encodeAscii("lib:").raw;
   const key = new Uint8Array(prefix.length + name.raw.length);
   key.set(prefix, 0);
   key.set(name.raw, prefix.length);
-  return key;
+  return BytesBlob.wrap(key);
 }

--- a/examples/library/assembly/storage.ts
+++ b/examples/library/assembly/storage.ts
@@ -41,9 +41,9 @@ export function libraryKey(name: string): BytesBlob {
 
 /** Build the storage key `"lib:<name>"` when `name` is already an ASCII byte blob. */
 export function libraryKeyFromBlob(name: BytesBlob): BytesBlob {
-  const prefix = BytesBlob.encodeAscii("lib:").raw;
-  const key = new Uint8Array(prefix.length + name.raw.length);
-  key.set(prefix, 0);
-  key.set(name.raw, prefix.length);
-  return BytesBlob.wrap(key);
+  const prefix = BytesBlob.encodeAscii("lib:");
+  const e = Encoder.create(prefix.length + name.length);
+  e.bytesFixLen(prefix);
+  e.bytesFixLen(name);
+  return e.finish();
 }

--- a/examples/pastebin/assembly/accumulate.ts
+++ b/examples/pastebin/assembly/accumulate.ts
@@ -28,11 +28,11 @@ function u32Blob(value: u32): BytesBlob {
  * service would want to either roll back the prior writes or surface the
  * failure in the accumulate Response.
  */
-function appendHashToExpiryBucket(storage: CurrentServiceData, bucketKey: Uint8Array, hash: Bytes32): void {
+function appendHashToExpiryBucket(storage: CurrentServiceData, bucketKey: BytesBlob, hash: Bytes32): void {
   const existing = storage.read(bucketKey);
   const prevLen: u32 = existing.isSome ? u32(existing.val!.length) : 0;
   const e = Encoder.create(prevLen + 32);
-  if (existing.isSome) e.bytesFixLen(BytesBlob.wrap(existing.val!));
+  if (existing.isSome) e.bytesFixLen(existing.val!);
   e.bytes32(hash);
   storage.write(bucketKey, e.finish());
 }
@@ -73,26 +73,26 @@ export function accumulate(ptr: u32, len: u32): u64 {
     const length = digest.length;
 
     // Idempotency: skip if this paste is already known.
-    const existing = storage.read(pasteKey(hash).raw);
+    const existing = storage.read(pasteKey(hash));
     if (!existing.isSome) {
       const solicitRes = preimages.solicit(hash, length);
       if (!solicitRes.isError) {
         // Metadata.
-        storage.write(pasteKey(hash).raw, PasteEntry.create(currentSlot, length).encode());
+        storage.write(pasteKey(hash), PasteEntry.create(currentSlot, length).encode());
 
         // Ring buffer of recent pastes: write hash ‖ slot at recent:<head % N>,
         // then bump the head counter.
-        const headBlob = storage.read(recentHeadKey().raw);
-        const head: u32 = headBlob.isSome ? Decoder.fromBlob(headBlob.val!).u32() : 0;
+        const headBlob = storage.read(recentHeadKey());
+        const head: u32 = headBlob.isSome ? Decoder.fromBlob(headBlob.val!.raw).u32() : 0;
         const entryEnc = Encoder.create(RECENT_ENTRY_LEN);
         entryEnc.bytes32(hash);
         entryEnc.u32(currentSlot);
-        storage.write(recentKey(head % RECENT_N).raw, entryEnc.finish());
-        storage.write(recentHeadKey().raw, u32Blob(head + 1));
+        storage.write(recentKey(head % RECENT_N), entryEnc.finish());
+        storage.write(recentHeadKey(), u32Blob(head + 1));
 
         // Expiry bucket.
         const expireAt: u32 = currentSlot + TTL_SLOTS;
-        appendHashToExpiryBucket(storage, expiryKey(expireAt).raw, hash);
+        appendHashToExpiryBucket(storage, expiryKey(expireAt), hash);
       }
       // On solicit failure, skip the insertion entirely.
     }
@@ -116,12 +116,12 @@ function runCleanup(storage: CurrentServiceData, preimages: AccumulatePreimages,
   // A wrong-length blob is host-contract corruption (the only writer is this
   // function, which always writes exactly 4 bytes) — panic, matching
   // PasteEntry.decodeOrPanic's posture on malformed internal records.
-  const cursorBlob = storage.read(cleanupCursorKey().raw);
+  const cursorBlob = storage.read(cleanupCursorKey());
   let cursor: u32 = 0;
   if (cursorBlob.isSome) {
     const raw = cursorBlob.val!;
     if (raw.length !== 4) panic("cleanup cursor: expected 4 bytes");
-    cursor = Decoder.fromBlob(raw).u32();
+    cursor = Decoder.fromBlob(raw.raw).u32();
   }
 
   // Walk at most CLEANUP_SLOTS_PER_CALL slots forward, bounded by currentSlot.
@@ -129,30 +129,30 @@ function runCleanup(storage: CurrentServiceData, preimages: AccumulatePreimages,
   const target: u32 = limit < currentSlot ? limit : currentSlot;
 
   for (let s: u32 = cursor + 1; s <= target; s += 1) {
-    const bucketKeyBytes = expiryKey(s).raw;
-    const bucket = storage.read(bucketKeyBytes);
+    const bucketKey = expiryKey(s);
+    const bucket = storage.read(bucketKey);
     if (!bucket.isSome) continue;
 
     // Bucket holds a packed list of 32-byte hashes — decode with the standard codec.
-    const d = Decoder.fromBlob(bucket.val!);
+    const d = Decoder.fromBlob(bucket.val!.raw);
     const bucketLen = u32(bucket.val!.length);
     while (u32(d.bytesRead()) + 32 <= bucketLen) {
       const hash = d.bytes32();
 
-      const entryBlob = storage.read(pasteKey(hash).raw);
+      const entryBlob = storage.read(pasteKey(hash));
       if (entryBlob.isSome) {
-        const entry = PasteEntry.decodeOrPanic(entryBlob.val!);
+        const entry = PasteEntry.decodeOrPanic(entryBlob.val!.raw);
         // forget result ignored: the paste metadata is being deleted either way.
         preimages.forget(hash, entry.length);
-        storage.write(pasteKey(hash).raw, BytesBlob.empty());
+        storage.write(pasteKey(hash), BytesBlob.empty());
       }
     }
     // Delete the bucket itself.
-    storage.write(bucketKeyBytes, BytesBlob.empty());
+    storage.write(bucketKey, BytesBlob.empty());
   }
 
   // Persist new cursor only if it advanced.
   if (target > cursor) {
-    storage.write(cleanupCursorKey().raw, u32Blob(target));
+    storage.write(cleanupCursorKey(), u32Blob(target));
   }
 }

--- a/examples/pastebin/assembly/pastebin.test.ts
+++ b/examples/pastebin/assembly/pastebin.test.ts
@@ -132,14 +132,14 @@ export const TESTS: Test[] = [
     // Paste entry should be present.
     const storage = CurrentServiceData.create();
     const hash = Bytes32.wrapUnchecked(hashBytes);
-    const stored = storage.read(pasteKey(hash).raw);
+    const stored = storage.read(pasteKey(hash));
     assert.isEqual(stored.isSome, true, "paste entry present");
     if (!stored.isSome) return assert;
     const raw = stored.val!;
     assert.isEqual(<u32>raw.length, <u32>8, "paste entry length");
     if (raw.length !== 8) return assert;
 
-    const entry = PasteEntry.decodeOrPanic(raw);
+    const entry = PasteEntry.decodeOrPanic(raw.raw);
     assert.isEqual(entry.slot, <u32>123, "paste entry slot");
     assert.isEqual(entry.length, <u32>8, "paste entry payload length");
     return assert;
@@ -161,11 +161,11 @@ export const TESTS: Test[] = [
 
     const storage = CurrentServiceData.create();
     const hash = Bytes32.wrapUnchecked(hashBytes);
-    const stored = storage.read(pasteKey(hash).raw);
+    const stored = storage.read(pasteKey(hash));
     assert.isEqual(stored.isSome, true, "paste entry present");
     if (!stored.isSome) return assert;
 
-    const entry = PasteEntry.decodeOrPanic(stored.val!);
+    const entry = PasteEntry.decodeOrPanic(stored.val!.raw);
     // First insertion's slot must be preserved — second call is a no-op.
     assert.isEqual(entry.slot, <u32>100, "paste entry slot preserved");
     assert.isEqual(entry.length, <u32>4, "paste entry payload length");
@@ -193,20 +193,20 @@ export const TESTS: Test[] = [
     // Paste entry should be gone.
     const storage = CurrentServiceData.create();
     const hash = Bytes32.wrapUnchecked(hashBytes);
-    const pasteStored = storage.read(pasteKey(hash).raw);
+    const pasteStored = storage.read(pasteKey(hash));
     assert.isEqual(pasteStored.isSome, false, "paste entry deleted after expiry");
 
     // Cursor advances by CLEANUP_SLOTS_PER_CALL (=8) on every accumulate
     // invocation: the initial insert + 130 empty calls = 131 × 8 = 1048.
     // Direct-observes the cursor persistence path so a future bug that
     // silently stops writing it can't hide behind the deletion assertion.
-    const cursorStored = storage.read(cleanupCursorKey().raw);
+    const cursorStored = storage.read(cleanupCursorKey());
     assert.isEqual(cursorStored.isSome, true, "cursor persisted");
     if (cursorStored.isSome) {
       const cursorVal = cursorStored.val!;
       assert.isEqual(<u32>cursorVal.length, <u32>4, "cursor blob length");
       if (cursorVal.length === 4) {
-        assert.isEqual(Decoder.fromBlob(cursorVal).u32(), <u32>1048, "cursor value");
+        assert.isEqual(Decoder.fromBlob(cursorVal.raw).u32(), <u32>1048, "cursor value");
       }
     }
 
@@ -289,7 +289,7 @@ export const TESTS: Test[] = [
     // No paste entry should have been written — insertion is gated on solicit success.
     const storage = CurrentServiceData.create();
     const hash = Bytes32.wrapUnchecked(hashBytes);
-    const stored = storage.read(pasteKey(hash).raw);
+    const stored = storage.read(pasteKey(hash));
     assert.isEqual(stored.isSome, false, "paste not stored after solicit failure");
     return assert;
   }),
@@ -317,7 +317,7 @@ export const TESTS: Test[] = [
 
     // Pre-cleanup: expiry bucket holds exactly 2 hashes (64 bytes).
     const storage = CurrentServiceData.create();
-    const bucket = storage.read(expiryKey(1005).raw);
+    const bucket = storage.read(expiryKey(1005));
     assert.isEqual(bucket.isSome, true, "expiry bucket exists pre-cleanup");
     if (bucket.isSome) assert.isEqual(<u32>bucket.val!.length, <u32>64, "bucket holds 2 hashes");
 
@@ -325,9 +325,9 @@ export const TESTS: Test[] = [
     for (let i: u32 = 0; i < 130; i += 1) callAccumulateEmpty(1005 + i);
 
     // Both pastes + the bucket itself should be gone.
-    assert.isEqual(storage.read(pasteKey(Bytes32.wrapUnchecked(hashA)).raw).isSome, false, "paste A deleted");
-    assert.isEqual(storage.read(pasteKey(Bytes32.wrapUnchecked(hashB)).raw).isSome, false, "paste B deleted");
-    assert.isEqual(storage.read(expiryKey(1005).raw).isSome, false, "bucket deleted");
+    assert.isEqual(storage.read(pasteKey(Bytes32.wrapUnchecked(hashA))).isSome, false, "paste A deleted");
+    assert.isEqual(storage.read(pasteKey(Bytes32.wrapUnchecked(hashB))).isSome, false, "paste B deleted");
+    assert.isEqual(storage.read(expiryKey(1005)).isSome, false, "bucket deleted");
     return assert;
   }),
 ];

--- a/sdk/core/byte-buf.ts
+++ b/sdk/core/byte-buf.ts
@@ -1,3 +1,5 @@
+import { BytesBlob } from "./bytes";
+
 /**
  * A lightweight byte-buffer builder that avoids AssemblyScript's String
  * machinery.  Append ASCII strings, raw byte slices, or decimal numbers,
@@ -146,6 +148,11 @@ export class ByteBuf {
     memory.copy(out.dataStart, this._ptr, this._pos);
     this._pos = 0;
     return out;
+  }
+
+  /** Copy the buffer contents into a new `BytesBlob`. */
+  finishBlob(): BytesBlob {
+    return BytesBlob.wrap(this.finish());
   }
 
   /** Reset the write position without producing output. */

--- a/sdk/jam/account-info.test.ts
+++ b/sdk/jam/account-info.test.ts
@@ -140,15 +140,15 @@ export const TESTS: Test[] = [
     TestStorage.set(strBlob("testkey"), val);
 
     const svc = ServiceData.create(42);
-    const key = ByteBuf.create(32).strAscii("testkey").finish();
+    const key = ByteBuf.create(32).strAscii("testkey").finishBlob();
     const result = svc.read(key);
     a.isEqual(result.isSome, true, "should be some");
     const data = result.val!;
     a.isEqual(data.length, 4, "length");
-    a.isEqual(data[0], 0xde, "byte 0");
-    a.isEqual(data[1], 0xad, "byte 1");
-    a.isEqual(data[2], 0xbe, "byte 2");
-    a.isEqual(data[3], 0xef, "byte 3");
+    a.isEqual(data.raw[0], 0xde, "byte 0");
+    a.isEqual(data.raw[1], 0xad, "byte 1");
+    a.isEqual(data.raw[2], 0xbe, "byte 2");
+    a.isEqual(data.raw[3], 0xef, "byte 3");
     return a;
   }),
 
@@ -157,7 +157,7 @@ export const TESTS: Test[] = [
     const a = Assert.create();
 
     const svc = ServiceData.create(42);
-    const key = ByteBuf.create(32).strAscii("nonexistent").finish();
+    const key = ByteBuf.create(32).strAscii("nonexistent").finishBlob();
     const result = svc.read(key);
     a.isEqual(result.isSome, false, "should be none");
     return a;
@@ -172,15 +172,15 @@ export const TESTS: Test[] = [
 
     // Create with small buffer (64 bytes) to force auto-expansion
     const svc = ServiceData.create(42, 64);
-    const key = ByteBuf.create(32).strAscii("bigkey").finish();
+    const key = ByteBuf.create(32).strAscii("bigkey").finishBlob();
     const result = svc.read(key);
     a.isEqual(result.isSome, true, "should be some");
     const data = result.val!;
     a.isEqual(data.length, 2048, "length");
-    a.isEqual(data[0], 0, "byte 0");
-    a.isEqual(data[1], 1, "byte 1");
-    a.isEqual(data[255], 255, "byte 255");
-    a.isEqual(data[256], 0, "byte 256 wraps");
+    a.isEqual(data.raw[0], 0, "byte 0");
+    a.isEqual(data.raw[1], 1, "byte 1");
+    a.isEqual(data.raw[255], 255, "byte 255");
+    a.isEqual(data.raw[256], 0, "byte 256 wraps");
     return a;
   }),
 
@@ -191,7 +191,7 @@ export const TESTS: Test[] = [
     const a = Assert.create();
 
     const svc = CurrentServiceData.create();
-    const key = ByteBuf.create(32).strAscii("newkey").finish();
+    const key = ByteBuf.create(32).strAscii("newkey").finishBlob();
     const val = BytesBlob.parseBlob("0x010203").okay!;
     const result = svc.write(key, val);
     a.isEqual(result.isOkay, true, "should be ok");
@@ -204,7 +204,7 @@ export const TESTS: Test[] = [
     const a = Assert.create();
 
     const svc = CurrentServiceData.create();
-    const key = ByteBuf.create(32).strAscii("overkey").finish();
+    const key = ByteBuf.create(32).strAscii("overkey").finishBlob();
     const val1 = BytesBlob.zero(5);
     val1.raw.fill(0xaa);
     const val2 = BytesBlob.zero(3);
@@ -214,7 +214,7 @@ export const TESTS: Test[] = [
     svc.write(key, val1);
 
     // Second write — should return previous length (5)
-    const key2 = ByteBuf.create(32).strAscii("overkey").finish();
+    const key2 = ByteBuf.create(32).strAscii("overkey").finishBlob();
     const result = svc.write(key2, val2);
     a.isEqual(result.isOkay, true, "should be ok");
     a.isEqual(result.okay!.isSome, true, "has previous value");
@@ -227,20 +227,20 @@ export const TESTS: Test[] = [
     const a = Assert.create();
 
     const svc = CurrentServiceData.create();
-    const key = ByteBuf.create(32).strAscii("rtkey").finish();
+    const key = ByteBuf.create(32).strAscii("rtkey").finishBlob();
     const val = BytesBlob.parseBlob("0xcafebabe").okay!;
 
     svc.write(key, val);
 
-    const key2 = ByteBuf.create(32).strAscii("rtkey").finish();
+    const key2 = ByteBuf.create(32).strAscii("rtkey").finishBlob();
     const result = svc.read(key2);
     a.isEqual(result.isSome, true, "should be some");
     const data = result.val!;
     a.isEqual(data.length, 4, "length");
-    a.isEqual(data[0], 0xca, "byte 0");
-    a.isEqual(data[1], 0xfe, "byte 1");
-    a.isEqual(data[2], 0xba, "byte 2");
-    a.isEqual(data[3], 0xbe, "byte 3");
+    a.isEqual(data.raw[0], 0xca, "byte 0");
+    a.isEqual(data.raw[1], 0xfe, "byte 1");
+    a.isEqual(data.raw[2], 0xba, "byte 2");
+    a.isEqual(data.raw[3], 0xbe, "byte 3");
     return a;
   }),
 ];

--- a/sdk/jam/service-data.ts
+++ b/sdk/jam/service-data.ts
@@ -59,19 +59,19 @@ export class ServiceData {
   }
 
   /** Read a value from storage by key. Returns None if the key does not exist. */
-  read(key: Uint8Array): Optional<Uint8Array> {
-    let result = read(this.serviceId, u32(key.dataStart), key.length, u32(this.buf.dataStart), 0, this.buf.length);
-    if (result === EcalliResult.NONE) return Optional.none<Uint8Array>();
+  read(key: BytesBlob): Optional<BytesBlob> {
+    let result = read(this.serviceId, key.ptr(), key.length, u32(this.buf.dataStart), 0, this.buf.length);
+    if (result === EcalliResult.NONE) return Optional.none<BytesBlob>();
 
     // Auto-expand: the host told us the total length exceeds our buffer.
     if (result > i64(this.buf.length)) {
       this.buf = new Uint8Array(u32(result));
-      result = read(this.serviceId, u32(key.dataStart), key.length, u32(this.buf.dataStart), 0, this.buf.length);
-      if (result === EcalliResult.NONE) return Optional.none<Uint8Array>();
+      result = read(this.serviceId, key.ptr(), key.length, u32(this.buf.dataStart), 0, this.buf.length);
+      if (result === EcalliResult.NONE) return Optional.none<BytesBlob>();
     }
 
     const len = u32(min(i64(this.buf.length), result));
-    return Optional.some<Uint8Array>(this.buf.slice(0, len));
+    return Optional.some<BytesBlob>(BytesBlob.wrap(this.buf.slice(0, len)));
   }
 }
 
@@ -91,8 +91,8 @@ export class CurrentServiceData extends ServiceData {
    * Fails with WriteError.Full if the storage quota is exceeded.
    * Pass `BytesBlob.empty()` to delete the entry.
    */
-  write(key: Uint8Array, value: BytesBlob): Result<OptionalN<u64>, WriteError> {
-    const result = write(u32(key.dataStart), key.length, value.ptr(), value.length);
+  write(key: BytesBlob, value: BytesBlob): Result<OptionalN<u64>, WriteError> {
+    const result = write(key.ptr(), key.length, value.ptr(), value.length);
     if (result === EcalliResult.FULL) return Result.err<OptionalN<u64>, WriteError>(WriteError.Full);
     if (result === EcalliResult.NONE) return Result.ok<OptionalN<u64>, WriteError>(OptionalN.none<u64>());
     return Result.ok<OptionalN<u64>, WriteError>(OptionalN.some<u64>(u64(result)));


### PR DESCRIPTION
## Summary

Closes #104.

- `ServiceData.read` now takes `BytesBlob` keys and returns `Optional<BytesBlob>` (previously `Uint8Array`). `CurrentServiceData.write` takes `BytesBlob` keys too.
- Adds `ByteBuf.finishBlob(): BytesBlob` as a `BytesBlob`-producing parallel to `.finish()`.
- Migrates the library and pastebin examples, their tests, and `account-info.test.ts` to the new signatures. Drops `.raw` key plumbing on call sites and folds `libraryKey*` helpers into `BytesBlob`-producing versions.
- Updates `docs/src/sdk-api/common.md` and `utilities.md`.

The low-level `read`/`write` ecalli wrappers in `sdk/ecalli/general/` keep their raw `(ptr, len)` ABI — out of scope per the issue.

## Test plan
- [x] `npm run qa` clean
- [x] `npm test` — all 314 tests green
- [x] No `Uint8Array` typed arguments/returns in `ServiceData`/`CurrentServiceData` public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)