### PR TITLE
docs: refresh quick start and fix scaffold script

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -14,7 +14,7 @@ This will:
 
 1. Create a `my-service/` directory with a git repo
 2. Add the as-lan SDK as a git submodule
-3. Download template files from the [fibonacci example](https://github.com/fluffylabs/as-lan/tree/main/examples/fibonacci) and patch paths
+3. Download template files from the [fibonacci example](https://github.com/tomusdrw/as-lan/tree/main/examples/fibonacci) and patch paths
 4. Run `npm install`
 
 ## What You Get
@@ -44,37 +44,32 @@ The ecalli host call stubs used for testing live in `sdk/sdk-ecalli-mocks/` and 
 
 ## Implement Your Service
 
-Edit `assembly/fibonacci.ts` (rename it to match your service). You need to implement `refine` and `accumulate` functions (or `is_authorized` for an authorizer service — see the [authorizer example](https://github.com/fluffylabs/as-lan/tree/main/examples/authorizer) and the [SDK API entry point pattern](./sdk-api/authorize.md)).
+Edit `assembly/fibonacci.ts` (rename it to match your service). You need to implement `refine` and `accumulate` functions (or `is_authorized` for an authorizer service — see the [authorizer example](https://github.com/tomusdrw/as-lan/tree/main/examples/authorizer) and the [SDK API entry point pattern](./sdk-api/authorize.md)).
 
-Each function takes `(ptr: u32, len: u32)` raw memory arguments and returns a packed `u64` result. The SDK provides helpers for parsing arguments, and results are returned by calling `.toPtrAndLen()` on a `BytesBlob`:
+Each function takes `(ptr: u32, len: u32)` raw memory arguments and returns a packed `u64` result. Create a context (`AccumulateContext` / `RefineContext`) inside the entry point to parse args and build the response. `ctx.parseArgs()` panics if the host hands back malformed data — that is a host-contract violation, not a recoverable error, so the entry point does not need to handle it.
 
 ```typescript
-import { Logger, Optional, RefineArgs, AccumulateArgs, encodeOptionalCodeHash } from "@fluffylabs/as-lan";
-import { CodeHash } from "@fluffylabs/as-lan";
+import { AccumulateContext, RefineContext, LogMsg } from "@fluffylabs/as-lan";
 
-const logger = Logger.create("my-service");
+// LogMsg is a lightweight buffer-based logger that avoids pulling in
+// AssemblyScript's String machinery. You can also use `Logger.create("my-service")`
+// with template literals for convenience (at a ~24% WASM size cost).
+const logger: LogMsg = LogMsg.create("my-service");
 
 export function accumulate(ptr: u32, len: u32): u64 {
-  const result = AccumulateArgs.parse(ptr, len);
-  if (result.isError) {
-    logger.warn(`Failed to parse accumulate args: ${result.error}`);
-    return 0;
-  }
-  const args = result.okay!;
-  logger.info(`accumulate called for service ${args.serviceId} at slot ${args.slot}`);
-  // TODO: implement your accumulate logic here
-  return encodeOptionalCodeHash(Optional.none<CodeHash>()).toPtrAndLen();
+  const ctx = AccumulateContext.create();
+  const args = ctx.parseArgs(ptr, len);
+  logger.str("accumulate, service ").u32(args.serviceId).str(" @").u32(args.slot).info();
+  // TODO: implement your accumulate logic here.
+  // Return an Optional<CodeHash> (null = no upgrade) via ctx.yieldHash.
+  return ctx.yieldHash(null);
 }
 
 export function refine(ptr: u32, len: u32): u64 {
-  const result = RefineArgs.parse(ptr, len);
-  if (result.isError) {
-    logger.warn(`Failed to parse refine args: ${result.error}`);
-    return 0;
-  }
-  const args = result.okay!;
-  logger.info(`refine called for service ${args.serviceId}`);
-  // TODO: implement your refine logic here — for now, echo payload back
+  const ctx = RefineContext.create();
+  const args = ctx.parseArgs(ptr, len);
+  logger.str("refine, service ").u32(args.serviceId).info();
+  // TODO: implement your refine logic here — for now, echo payload back.
   return args.payload.toPtrAndLen();
 }
 ```

--- a/docs/src/sdk-api.md
+++ b/docs/src/sdk-api.md
@@ -15,16 +15,25 @@ wrappers available during that entry point.
 Each example in `examples/` is a self-contained service that exercises a
 particular slice of the SDK. Browse the source for end-to-end patterns.
 
-- **[fibonacci](https://github.com/fluffylabs/as-lan/tree/main/examples/fibonacci)**
+- **[fibonacci](https://github.com/tomusdrw/as-lan/tree/main/examples/fibonacci)**
   — minimal refine + accumulate, starter template.
-- **[authorizer](https://github.com/fluffylabs/as-lan/tree/main/examples/authorizer)**
+- **[authorizer](https://github.com/tomusdrw/as-lan/tree/main/examples/authorizer)**
   — standalone `is_authorized` service with gating logic.
-- **[ecalli-test](https://github.com/fluffylabs/as-lan/tree/main/examples/ecalli-test)**
+- **[ecalli-test](https://github.com/tomusdrw/as-lan/tree/main/examples/ecalli-test)**
   — dispatches every ecalli host call for smoke-testing the SDK surface.
-- **[pastebin](https://github.com/fluffylabs/as-lan/tree/main/examples/pastebin)**
+- **[all-ecalli](https://github.com/tomusdrw/as-lan/tree/main/examples/all-ecalli)**
+  — self-authorizing service that invokes every ecalli across refine,
+  accumulate, and authorize entry points.
+- **[pastebin](https://github.com/tomusdrw/as-lan/tree/main/examples/pastebin)**
   — open-submission paste service. Refine hashes the payload with
   Blake2b-256; accumulate solicits the preimage and records metadata in a
   storage-backed ring buffer plus a slot-bucketed TTL index. Preimage bytes
   arrive via the `xtpreimages` block extrinsic — accumulate never calls
   `provide`. Good reference for the solicit-only preimage lifecycle and
   slot-bucket cleanup patterns.
+- **[library](https://github.com/tomusdrw/as-lan/tree/main/examples/library)**
+  — hosts reusable PVM verification blobs as SPI-encoded preimages keyed
+  by name, resolved and executed via `ctx.nestedPvmFromSpiChecked(...)`.
+- **[nested-pvm-spi](https://github.com/tomusdrw/as-lan/tree/main/examples/nested-pvm-spi)**
+  — minimal smoke test for the inner PVM: loads an embedded SPI blob and
+  runs it through `ctx.nestedPvmFromSpiChecked`.

--- a/docs/src/sdk-api/accumulate.md
+++ b/docs/src/sdk-api/accumulate.md
@@ -18,7 +18,9 @@ export function accumulate(ptr: u32, len: u32): u64 {
 
   const gasLeft = ctx.remainingGas();    // i64 — ecalli 0
   const gas = ctx.checkpoint();          // i64 — commit state, return remaining gas
-  ctx.yieldResult(Bytes32.zero());       // provide accumulation result hash
+
+  // ecalli 25 — publish the accumulation result hash (side effect, no return).
+  ctx.yieldResult(Bytes32.zero());
 
   // Create helpers via the context
   const fetcher = ctx.fetcher();         // AccumulateFetcher
@@ -35,6 +37,7 @@ export function accumulate(ptr: u32, len: u32): u64 {
   const memo = Memo.create(BytesBlob.encodeAscii("hello"));
   const r2 = ctx.scheduleTransfer(42, 1000, 100, memo);
 
+  // Encode the entry-point return value: Optional<CodeHash> (null = no upgrade).
   return ctx.yieldHash(null);
 }
 ```

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -357,8 +357,8 @@ TestEcalli.reset();
 | `provide()` | Returns `OK` (0) |
 
 
-See the [fibonacci](https://github.com/fluffylabs/as-lan/tree/main/examples/fibonacci)
-and [ecalli-test](https://github.com/fluffylabs/as-lan/tree/main/examples/ecalli-test)
+See the [fibonacci](https://github.com/tomusdrw/as-lan/tree/main/examples/fibonacci)
+and [ecalli-test](https://github.com/tomusdrw/as-lan/tree/main/examples/ecalli-test)
 examples for usage examples.
 
 ## Authoring new test helpers

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,7 +12,7 @@ if [ $# -lt 1 ]; then
 fi
 
 NAME="$1"
-AS_LAN_REPO="${AS_LAN_REPO:-https://github.com/fluffylabs/as-lan.git}"
+AS_LAN_REPO="${AS_LAN_REPO:-https://github.com/tomusdrw/as-lan.git}"
 BASE_URL="${BASE_URL:-https://todr.me/as-lan/fibonacci}"
 
 if [ -d "$NAME" ]; then
@@ -38,8 +38,6 @@ FILES=(
   assembly/index.test.ts
   assembly/test-run.ts
   assembly/tsconfig.json
-  ecalli/index.js
-  ecalli/package.json
   bin/test.js
   package.json
 )
@@ -50,9 +48,12 @@ for file in "${FILES[@]}"; do
   curl -sfL "$BASE_URL/$file" -o "$file"
 done
 
-# --- Patch package.json: name, SDK path, PVM adapter path ---
+# --- Patch package.json: name, SDK path, ecalli mocks path, PVM adapter path ---
+# Order matters: rewrite the longer `sdk-ecalli-mocks` path before the
+# shorter `sdk` path so the latter doesn't also match inside the former.
 sed -i.bak \
   -e "s|@fluffylabs/as-lan-fibonacci-example|$NAME|" \
+  -e 's|file:../../sdk-ecalli-mocks|file:./sdk/sdk-ecalli-mocks|' \
   -e 's|file:../../sdk|file:./sdk|' \
   -e 's|../../pvm-adapter.wat|./sdk/pvm-adapter.wat|' \
   package.json


### PR DESCRIPTION
## Summary

- Rewrite the Quick Start code example to match the current SDK: `AccumulateContext` / `RefineContext` + `ctx.parseArgs` + `ctx.yieldHash`, `LogMsg` logger. The old example imported the nonexistent `encodeOptionalCodeHash` and called removed `AccumulateArgs.parse` / `RefineArgs.parse` Result helpers.
- Add `all-ecalli`, `library`, and `nested-pvm-spi` to the examples index in `sdk-api.md`.
- Disambiguate `ctx.yieldResult` (ecalli 25 side effect) vs `ctx.yieldHash` (entry-point response encoder) in the `accumulate.md` kitchen-sink example.
- Fix `scripts/start.sh`: drop the `ecalli/index.js` / `ecalli/package.json` entries that 404 now that `examples/fibonacci` no longer ships a per-project `ecalli/` directory, and add a sed rule to rewrite `"ecalli": "file:../../sdk-ecalli-mocks"` → `"file:./sdk/sdk-ecalli-mocks"` in the scaffolded `package.json`.

## Test plan

- [x] `npm run build` and `npm test` pass locally via pre-push hook.
- [ ] After merge + Pages deploy, run `curl -sL https://todr.me/as-lan/start.sh | bash -s my-service` end-to-end to confirm the scaffold completes without 404s and the generated project builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)