### PR TITLE
ci: add jammin-compatible builder image + publish workflow

### DIFF
--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -1,0 +1,92 @@
+name: Build jammin-as-lan image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/fluffylabs/jammin-as-lan
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read @fluffylabs/as-lan version
+        id: pkg
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            if [[ "$TAG_VERSION" != "${{ steps.pkg.outputs.version }}" ]]; then
+              echo "::error::git tag ($TAG_VERSION) does not match package.json version (${{ steps.pkg.outputs.version }})"
+              exit 1
+            fi
+            {
+              echo "primary=${IMAGE}:${TAG_VERSION}"
+              echo "tags<<EOF"
+              echo "${IMAGE}:${TAG_VERSION}"
+              echo "${IMAGE}:latest"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "primary=${IMAGE}:main-${SHORT_SHA}"
+              echo "tags<<EOF"
+              echo "${IMAGE}:main-${SHORT_SHA}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (load into local docker for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/jammin-as-lan.Dockerfile
+          load: true
+          tags: ${{ steps.tags.outputs.primary }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — wasm-pvm and node on PATH
+        run: |
+          set -eux
+          docker run --rm "${{ steps.tags.outputs.primary }}" wasm-pvm --version
+          docker run --rm "${{ steps.tags.outputs.primary }}" node --version
+
+      - name: Report uncompressed image size
+        run: |
+          docker image inspect "${{ steps.tags.outputs.primary }}" \
+            --format 'uncompressed size: {{.Size}} bytes'
+
+      - name: Push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/jammin-as-lan.Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/jammin-as-lan.Dockerfile
+++ b/docker/jammin-as-lan.Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+#
+# Builder image for the @fluffylabs/as-lan SDK, compatible with jammin.
+# Two-stage: stage 1 compiles wasm-pvm-cli from crates.io, stage 2 is a
+# minimal node:22-slim runtime carrying only the resulting binary.
+
+# ---- Stage 1: build wasm-pvm ---------------------------------------------
+FROM rust:1-slim AS builder
+
+# wasm-pvm-cli needs llvm-18 headers + libpolly at compile time.
+# llvm-18 is not in Debian bookworm main, but is in bookworm-backports.
+RUN set -eux; \
+    echo 'deb http://deb.debian.org/debian bookworm-backports main' \
+        > /etc/apt/sources.list.d/backports.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        build-essential \
+        pkg-config; \
+    apt-get install -y --no-install-recommends -t bookworm-backports \
+        llvm-18-dev \
+        libpolly-18-dev; \
+    rm -rf /var/lib/apt/lists/*
+
+# Pin to 0.8.0 with --locked for reproducible builds.
+# $CARGO_HOME is /usr/local/cargo in the official rust image, so the
+# resulting binary lands at /usr/local/cargo/bin/wasm-pvm.
+RUN cargo install wasm-pvm-cli@0.8.0 --locked
+
+# ---- Stage 2: runtime ----------------------------------------------------
+FROM node:22-slim AS runtime
+
+# ca-certificates: npm registry TLS. git: npm deps pointing at git URLs.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/wasm-pvm /usr/local/bin/wasm-pvm
+
+WORKDIR /app
+
+# jammin passes the command to `docker run` directly, so no ENTRYPOINT.
+# The default CMD is a convenience for `docker run <image>` without args.
+CMD ["sh", "-c", "npm install && npm run build"]


### PR DESCRIPTION
## Summary

- Adds a two-stage Dockerfile (`docker/jammin-as-lan.Dockerfile`) producing a `node:22-slim` runtime image carrying a reproducible `wasm-pvm-cli@0.8.0 --locked` binary built in a throwaway `rust:1-slim` stage. No ENTRYPOINT — jammin passes the command to `docker run` directly. Default `CMD` runs `npm install && npm run build`.
- Adds `.github/workflows/docker-jammin.yml` that publishes to `ghcr.io/fluffylabs/jammin-as-lan` — `:<version>` + `:latest` on release tags (`v*`), `:main-<sha>` on pushes to `main`. The workflow guards against a git tag that disagrees with `package.json` version.
- Smoke-tests the image before push: loads it locally, runs `wasm-pvm --version` and `node --version`, and reports uncompressed size.
- Builder stage uses `bookworm-backports` for `llvm-18-dev` + `libpolly-18-dev` (matches the existing CI in `build.yml`). Runtime stage installs only `ca-certificates` and `git` (for npm git deps), cleans `/var/lib/apt/lists/*`.

## Caveats to verify in CI

- **libLLVM at runtime** — if the built `wasm-pvm` binary dynamically links `libLLVM-18.so`, the runtime stage will fail the smoke test. Fix would be to add `libllvm18` from backports (~80 MB) to the runtime stage. The smoke test will catch it.
- **Size target (< 300 MB)** — `node:22-slim` (~245 MB) + ca-certs + git + wasm-pvm binary will likely land around 290–330 MB. The workflow prints the uncompressed size on each build.
- **Token scopes** — first run requires ghcr.io to accept a `GITHUB_TOKEN` push to `ghcr.io/fluffylabs/jammin-as-lan`; confirm package visibility settings match expectations.

## Test plan

- [ ] CI green on this PR (builds the image, smoke test passes).
- [ ] `:main-<sha>` tag appears under `ghcr.io/fluffylabs/jammin-as-lan/tags` after merge to `main`.
- [ ] Cut a `v0.0.2` (or whichever) tag once ready and confirm `:<version>` + `:latest` get published.
- [ ] Confirm uncompressed size from the "Report uncompressed image size" step; adjust if > 300 MB feels too fat.
- [ ] Sanity-check with jammin: `docker run --rm ghcr.io/fluffylabs/jammin-as-lan:main-<sha> sh -c "npm install && npm run build"` inside a checked-out as-lan consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)