### PR TITLE
fix: drop redundant non-null assertions on ResultN.okay

### DIFF
--- a/examples/nested-pvm-spi/assembly/refine.ts
+++ b/examples/nested-pvm-spi/assembly/refine.ts
@@ -64,7 +64,7 @@ export function refine(ptr: u32, len: u32): u64 {
     logger.warn(`refine: SPI setup failed error=${vmR.error}`);
     return ctx.respond(-1);
   }
-  const vm = vmR.okay!;
+  const vm = vmR.okay;
 
   // One invoke is enough for a smoke test — a real service would loop on
   // ExitReason.Host and dispatch host calls by index via vm.getExitArg().

--- a/sdk/jam/refine/nested-pvm.ts
+++ b/sdk/jam/refine/nested-pvm.ts
@@ -76,7 +76,7 @@ export class NestedPvm {
     if (machineResult.isError) {
       return ResultN.err<NestedPvm, SpiError>(SpiError.InvalidEntryPoint);
     }
-    const machine = machineResult.okay!;
+    const machine = machineResult.okay;
 
     const io = InvokeIo.create(gas);
     io.setRegister(0, R0_INITIAL);


### PR DESCRIPTION
## Summary
- `ResultN.okay` is typed `Ok` (non-nullable); only `Result.okay` is `Ok | null`. The `!` non-null assertions on `ResultN.okay` were redundant and triggered AS210 *"Expression is never 'null'"* warnings.
- Dropped the `!` at the two reported sites: `sdk/jam/refine/nested-pvm.ts:79` and `examples/nested-pvm-spi/assembly/refine.ts:67`.

## Test plan
- [x] `npm test` — all SDK + example tests pass
- [x] `asc` build produces no AS210 warnings for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)