### PR TITLE
ci: fix jammin docker build (missing zlib/zstd dev libs)

### DIFF
--- a/docker/jammin-as-lan.Dockerfile
+++ b/docker/jammin-as-lan.Dockerfile
@@ -16,7 +16,9 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         build-essential \
-        pkg-config; \
+        pkg-config \
+        zlib1g-dev \
+        libzstd-dev; \
     apt-get install -y --no-install-recommends -t bookworm-backports \
         llvm-18-dev \
         libpolly-18-dev; \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluffylabs/as-lan-workspace",
-  "version": "9.9.9",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluffylabs/as-lan-workspace",
-      "version": "9.9.9",
+      "version": "0.0.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",


### PR DESCRIPTION
## Summary

The `Build jammin-as-lan image` workflow has been failing on every push to main since it was added in #115. `cargo install wasm-pvm-cli@0.8.0 --locked` fails at the link step:

```
rust-lld: error: unable to find library -lz
rust-lld: error: unable to find library -lzstd
collect2: error: ld returned 1 exit status
```

`llvm-18-dev` dynamically links against zlib and zstd, but the runtime shared libs pulled in transitively don't ship the `*.so` symlinks the linker needs. Added `zlib1g-dev` and `libzstd-dev` to the first apt-get install (both are in standard bookworm, no need for backports).

## Test plan

- [ ] Build jammin-as-lan workflow goes green on this branch / on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)