### PR TITLE
ci: push jammin image under repo owner's ghcr namespace

### DIFF
--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -9,9 +9,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-env:
-  IMAGE: ghcr.io/${{ github.repository_owner }}/jammin-as-lan
-
 jobs:
   build:
     # Builds the image and runs smoke tests. Runs on every trigger, including
@@ -36,11 +33,14 @@ jobs:
       - name: Compute image tags
         id: tags
         env:
+          REPO_OWNER: ${{ github.repository_owner }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
+          # ghcr refs must be lowercase; repo owner can be mixed-case (e.g. FluffyLabs).
+          IMAGE="ghcr.io/${REPO_OWNER,,}/jammin-as-lan"
           if [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_VERSION="${RELEASE_TAG_NAME#v}"
             SDK_VERSION=$(node -p "require('./sdk/package.json').version")

--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE: ghcr.io/fluffylabs/jammin-as-lan
+  IMAGE: ghcr.io/${{ github.repository_owner }}/jammin-as-lan
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- The jammin docker image was hardcoded to `ghcr.io/fluffylabs/jammin-as-lan`, but the workflow runs in `tomusdrw/as-lan` whose `GITHUB_TOKEN` has no `packages:write` on the FluffyLabs org — push failed with `denied: permission_denied: The requested installation does not exist.` ([run 24890422081](https://github.com/tomusdrw/as-lan/actions/runs/24890422081)).
- Resolve the namespace from `github.repository_owner` so the image tracks the repo owner and will auto-follow if/when the repo moves to FluffyLabs. Net effect for now: pushes go to `ghcr.io/tomusdrw/jammin-as-lan`.

## Test plan
- [ ] After merge, confirm the `build` and `push` jobs both succeed on the main-branch run.
- [ ] Confirm the image shows up under `ghcr.io/tomusdrw/jammin-as-lan` with the `main-<sha>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)