### PR TITLE
ci: build jammin image for linux/amd64 + linux/arm64

### DIFF
--- a/.github/workflows/_jammin-platform.yml
+++ b/.github/workflows/_jammin-platform.yml
@@ -1,0 +1,121 @@
+name: Build one jammin platform
+
+# Reusable workflow that builds a single platform of jammin-as-lan.
+#
+# Called twice from docker-jammin.yml: once in "smoke-test" mode (push=false,
+# runs on every trigger including PRs) and once in "publish" mode (push=true,
+# non-PR only). The two callers forward different permission sets so that the
+# packages:write token is never present in a runner that just executed
+# PR-supplied build code.
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Docker platform string (e.g. linux/amd64).'
+        type: string
+        required: true
+      runner:
+        description: 'GitHub Actions runner label native to `platform`.'
+        type: string
+        required: true
+      image:
+        description: 'Image name without a tag (e.g. ghcr.io/owner/jammin-as-lan).'
+        type: string
+        required: true
+      primary-tag:
+        description: 'Fully-qualified image:tag used to load and smoke-test the build locally.'
+        type: string
+        required: true
+      push:
+        description: 'When true, push the built image to GHCR by digest and upload the digest as an artifact.'
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      # Upper bound — the calling workflow's job permissions further constrain
+      # this. Smoke-test calls forward only `contents: read`; publish calls
+      # additionally forward `packages: write`.
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout (release tag)
+        if: github.event_name == 'release'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Checkout (branch or PR)
+        if: github.event_name != 'release'
+        uses: actions/checkout@v6
+
+      - name: Normalize platform label
+        id: platform
+        run: |
+          p='${{ inputs.platform }}'
+          echo "pair=${p//\//-}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build image (load into local docker for smoke test)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/jammin-as-lan.Dockerfile
+          platforms: ${{ inputs.platform }}
+          load: true
+          tags: ${{ inputs.primary-tag }}
+          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ steps.platform.outputs.pair }}
+
+      - name: Smoke test — wasm-pvm and node on PATH
+        run: |
+          set -eux
+          # wasm-pvm is a subcommand-style CLI; --help is the built-in
+          # clap flag that exits 0 and proves the binary loaded without
+          # dynamic-linker errors (glibc version, missing shared libs, …).
+          docker run --rm "${{ inputs.primary-tag }}" wasm-pvm --help
+          docker run --rm "${{ inputs.primary-tag }}" node --version
+
+      - name: Report uncompressed image size
+        run: |
+          docker image inspect "${{ inputs.primary-tag }}" \
+            --format 'uncompressed size: {{.Size}} bytes'
+
+      - name: Login to GHCR
+        if: inputs.push
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        if: inputs.push
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/jammin-as-lan.Dockerfile
+          platforms: ${{ inputs.platform }}
+          outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
+
+      - name: Export digest
+        if: inputs.push
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.push.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: inputs.push
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -92,15 +92,10 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+  # Smoke-test build. Runs on every trigger (including PRs). No registry
+  # access — the Dockerfile cargo-installs a crate, whose build script runs
+  # arbitrary code, so we don't want packages:write here.
   build:
-    # Matrix over platforms, each built on a native runner. Public-repo
-    # workflows get free linux/arm64 runners (ubuntu-24.04-arm), avoiding
-    # QEMU — critical since the Dockerfile cargo-compiles wasm-pvm-cli
-    # with LLVM-18, which is too slow under emulation.
-    #
-    # Runs on every trigger (incl. PRs) for smoke testing. No registry
-    # access — the Dockerfile cargo-installs a crate, whose build script
-    # runs arbitrary code, so we don't want packages:write here.
     needs: tags
     strategy:
       fail-fast: false
@@ -110,58 +105,21 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-    steps:
-      - name: Checkout (release tag)
-        if: github.event_name == 'release'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
+    uses: ./.github/workflows/_jammin-platform.yml
+    with:
+      platform: ${{ matrix.platform }}
+      runner: ${{ matrix.runner }}
+      image: ${{ needs.tags.outputs.image }}
+      primary-tag: ${{ needs.tags.outputs.primary }}
+      push: false
 
-      - name: Checkout (branch or PR)
-        if: github.event_name != 'release'
-        uses: actions/checkout@v6
-
-      - name: Normalize platform label
-        id: platform
-        run: |
-          p='${{ matrix.platform }}'
-          echo "pair=${p//\//-}" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Build image (load into local docker for smoke test)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/jammin-as-lan.Dockerfile
-          platforms: ${{ matrix.platform }}
-          load: true
-          tags: ${{ needs.tags.outputs.primary }}
-          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
-          cache-to: type=gha,mode=max,scope=${{ steps.platform.outputs.pair }}
-
-      - name: Smoke test — wasm-pvm and node on PATH
-        run: |
-          set -eux
-          # wasm-pvm is a subcommand-style CLI; --help is the built-in
-          # clap flag that exits 0 and proves the binary loaded without
-          # dynamic-linker errors (glibc version, missing shared libs, …).
-          docker run --rm "${{ needs.tags.outputs.primary }}" wasm-pvm --help
-          docker run --rm "${{ needs.tags.outputs.primary }}" node --version
-
-      - name: Report uncompressed image size
-        run: |
-          docker image inspect "${{ needs.tags.outputs.primary }}" \
-            --format 'uncompressed size: {{.Size}} bytes'
-
+  # Publish per-platform digests. Skipped on PRs entirely so the
+  # packages:write token never lives in a runner that just ran untrusted PR
+  # code in `build`. Reuses the GHA cache populated by `build`, so the docker
+  # build is effectively a metadata replay.
   push:
-    # Pushes per-platform image digests to GHCR. Skipped on PRs entirely so
-    # that the packages:write token never lives in a runner that just ran
-    # untrusted PR code in `build`. Reuses the GHA cache populated by `build`,
-    # so the docker build is effectively a metadata replay.
     needs: [tags, build]
     if: github.event_name != 'pull_request'
     strategy:
@@ -172,59 +130,16 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-    steps:
-      - name: Checkout (release tag)
-        if: github.event_name == 'release'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Checkout (branch)
-        if: github.event_name != 'release'
-        uses: actions/checkout@v6
-
-      - name: Normalize platform label
-        id: platform
-        run: |
-          p='${{ matrix.platform }}'
-          echo "pair=${p//\//-}" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/jammin-as-lan.Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ needs.tags.outputs.image }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
-
-      - name: Export digest
-        run: |
-          mkdir -p "${RUNNER_TEMP}/digests"
-          digest="${{ steps.push.outputs.digest }}"
-          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ steps.platform.outputs.pair }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
+    uses: ./.github/workflows/_jammin-platform.yml
+    with:
+      platform: ${{ matrix.platform }}
+      runner: ${{ matrix.runner }}
+      image: ${{ needs.tags.outputs.image }}
+      primary-tag: ${{ needs.tags.outputs.primary }}
+      push: true
 
   merge:
     # Combines the per-platform digests pushed by the push matrix into a

--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -69,6 +69,18 @@ jobs:
               echo "tags<<EOF"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual dispatches can run from any branch/tag. Stamp the ref into
+            # the tag so ad-hoc builds don't masquerade as `main-*` outputs.
+            SHORT_SHA="${GITHUB_SHA::7}"
+            REF_SLUG="${GITHUB_REF_NAME//\//-}"
+            {
+              echo "image=${IMAGE}"
+              echo "primary=${IMAGE}:manual-${REF_SLUG}-${SHORT_SHA}"
+              echo "tags<<EOF"
+              echo "${IMAGE}:manual-${REF_SLUG}-${SHORT_SHA}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           else
             SHORT_SHA="${GITHUB_SHA::7}"
             {
@@ -211,6 +223,7 @@ jobs:
           TAGS: ${{ needs.tags.outputs.tags }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
           TAG_ARGS=()
           while IFS= read -r tag; do
             [[ -z "$tag" ]] && continue
@@ -220,6 +233,13 @@ jobs:
           for digest in *; do
             SOURCES+=("${IMAGE}@sha256:${digest}")
           done
+          # Must match the build matrix size. Guards against silent partial
+          # manifests if a future refactor breaks upload/download naming.
+          EXPECTED_PLATFORMS=2
+          if [[ "${#SOURCES[@]}" -ne "$EXPECTED_PLATFORMS" ]]; then
+            echo "::error::expected ${EXPECTED_PLATFORMS} platform digests, found ${#SOURCES[@]}"
+            exit 1
+          fi
           docker buildx imagetools create "${TAG_ARGS[@]}" "${SOURCES[@]}"
 
       - name: Inspect pushed manifest

--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -10,13 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    # Builds the image and runs smoke tests. Runs on every trigger, including
-    # pull_request. Does not need packages:write — the push job handles that.
+  tags:
+    # Compute the image name, primary tag, and full tag list once. Both the
+    # per-platform build matrix and the manifest-merge job consume these.
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
+      image: ${{ steps.tags.outputs.image }}
       primary: ${{ steps.tags.outputs.primary }}
       tags: ${{ steps.tags.outputs.tags }}
     steps:
@@ -51,6 +52,7 @@ jobs:
               exit 1
             fi
             {
+              echo "image=${IMAGE}"
               echo "primary=${IMAGE}:${TAG_VERSION}"
               echo "tags<<EOF"
               echo "${IMAGE}:${TAG_VERSION}"
@@ -62,6 +64,7 @@ jobs:
             # commit) so the tag points at the contributor's actual commit.
             SHORT_SHA="${PR_HEAD_SHA::7}"
             {
+              echo "image=${IMAGE}"
               echo "primary=${IMAGE}:pr-${PR_NUMBER}-${SHORT_SHA}"
               echo "tags<<EOF"
               echo "EOF"
@@ -69,6 +72,7 @@ jobs:
           else
             SHORT_SHA="${GITHUB_SHA::7}"
             {
+              echo "image=${IMAGE}"
               echo "primary=${IMAGE}:main-${SHORT_SHA}"
               echo "tags<<EOF"
               echo "${IMAGE}:main-${SHORT_SHA}"
@@ -76,38 +80,21 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Build image (load into local docker for smoke test)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/jammin-as-lan.Dockerfile
-          load: true
-          tags: ${{ steps.tags.outputs.primary }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test — wasm-pvm and node on PATH
-        run: |
-          set -eux
-          # wasm-pvm is a subcommand-style CLI; --help is the built-in
-          # clap flag that exits 0 and proves the binary loaded without
-          # dynamic-linker errors (glibc version, missing shared libs, …).
-          docker run --rm "${{ steps.tags.outputs.primary }}" wasm-pvm --help
-          docker run --rm "${{ steps.tags.outputs.primary }}" node --version
-
-      - name: Report uncompressed image size
-        run: |
-          docker image inspect "${{ steps.tags.outputs.primary }}" \
-            --format 'uncompressed size: {{.Size}} bytes'
-
-  push:
-    # Pushes to GHCR. Scoped to trusted triggers only; PRs never reach this
-    # job, so packages:write is structurally unavailable to PR runs.
-    needs: build
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+  build:
+    # Matrix over platforms, each built on a native runner. Public-repo
+    # workflows get free linux/arm64 runners (ubuntu-24.04-arm), avoiding
+    # QEMU — critical since the Dockerfile cargo-compiles wasm-pvm-cli
+    # with LLVM-18, which is too slow under emulation.
+    needs: tags
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -118,24 +105,124 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Checkout (branch)
+      - name: Checkout (branch or PR)
         if: github.event_name != 'release'
         uses: actions/checkout@v6
 
+      - name: Normalize platform label
+        id: platform
+        run: |
+          p='${{ matrix.platform }}'
+          echo "pair=${p//\//-}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v4
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
+      - name: Build image (load into local docker for smoke test)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/jammin-as-lan.Dockerfile
-          push: true
-          tags: ${{ needs.build.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ${{ needs.tags.outputs.primary }}
+          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ steps.platform.outputs.pair }}
+
+      - name: Smoke test — wasm-pvm and node on PATH
+        run: |
+          set -eux
+          # wasm-pvm is a subcommand-style CLI; --help is the built-in
+          # clap flag that exits 0 and proves the binary loaded without
+          # dynamic-linker errors (glibc version, missing shared libs, …).
+          docker run --rm "${{ needs.tags.outputs.primary }}" wasm-pvm --help
+          docker run --rm "${{ needs.tags.outputs.primary }}" node --version
+
+      - name: Report uncompressed image size
+        run: |
+          docker image inspect "${{ needs.tags.outputs.primary }}" \
+            --format 'uncompressed size: {{.Size}} bytes'
+
+      - name: Push by digest
+        if: github.event_name != 'pull_request'
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/jammin-as-lan.Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.tags.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.push.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # Combines the per-platform digests pushed by the build matrix into a
+    # single multi-arch manifest list and tags it. Skipped on PRs — they
+    # never push.
+    needs: [tags, build]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ needs.tags.outputs.image }}
+          TAGS: ${{ needs.tags.outputs.tags }}
+        run: |
+          set -euo pipefail
+          TAG_ARGS=()
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            TAG_ARGS+=("-t" "$tag")
+          done <<< "$TAGS"
+          SOURCES=()
+          for digest in *; do
+            SOURCES+=("${IMAGE}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${TAG_ARGS[@]}" "${SOURCES[@]}"
+
+      - name: Inspect pushed manifest
+        env:
+          IMAGE: ${{ needs.tags.outputs.primary }}
+        run: docker buildx imagetools inspect "$IMAGE"

--- a/.github/workflows/docker-jammin.yml
+++ b/.github/workflows/docker-jammin.yml
@@ -97,6 +97,10 @@ jobs:
     # workflows get free linux/arm64 runners (ubuntu-24.04-arm), avoiding
     # QEMU — critical since the Dockerfile cargo-compiles wasm-pvm-cli
     # with LLVM-18, which is too slow under emulation.
+    #
+    # Runs on every trigger (incl. PRs) for smoke testing. No registry
+    # access — the Dockerfile cargo-installs a crate, whose build script
+    # runs arbitrary code, so we don't want packages:write here.
     needs: tags
     strategy:
       fail-fast: false
@@ -109,7 +113,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout (release tag)
         if: github.event_name == 'release'
@@ -128,14 +131,6 @@ jobs:
           echo "pair=${p//\//-}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
-
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image (load into local docker for smoke test)
         uses: docker/build-push-action@v7
@@ -162,8 +157,52 @@ jobs:
           docker image inspect "${{ needs.tags.outputs.primary }}" \
             --format 'uncompressed size: {{.Size}} bytes'
 
-      - name: Push by digest
-        if: github.event_name != 'pull_request'
+  push:
+    # Pushes per-platform image digests to GHCR. Skipped on PRs entirely so
+    # that the packages:write token never lives in a runner that just ran
+    # untrusted PR code in `build`. Reuses the GHA cache populated by `build`,
+    # so the docker build is effectively a metadata replay.
+    needs: [tags, build]
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout (release tag)
+        if: github.event_name == 'release'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Checkout (branch)
+        if: github.event_name != 'release'
+        uses: actions/checkout@v6
+
+      - name: Normalize platform label
+        id: platform
+        run: |
+          p='${{ matrix.platform }}'
+          echo "pair=${p//\//-}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
         id: push
         uses: docker/build-push-action@v7
         with:
@@ -174,14 +213,12 @@ jobs:
           cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
           digest="${{ steps.push.outputs.digest }}"
           touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ steps.platform.outputs.pair }}
@@ -190,10 +227,10 @@ jobs:
           retention-days: 1
 
   merge:
-    # Combines the per-platform digests pushed by the build matrix into a
+    # Combines the per-platform digests pushed by the push matrix into a
     # single multi-arch manifest list and tags it. Skipped on PRs — they
     # never push.
-    needs: [tags, build]
+    needs: [tags, push]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -242,7 +279,29 @@ jobs:
           fi
           docker buildx imagetools create "${TAG_ARGS[@]}" "${SOURCES[@]}"
 
-      - name: Inspect pushed manifest
+      - name: Inspect pushed manifest and assert platform coverage
         env:
           IMAGE: ${{ needs.tags.outputs.primary }}
-        run: docker buildx imagetools inspect "$IMAGE"
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "$IMAGE"
+          # Belt-and-braces: the digest count check earlier guarantees we
+          # passed the right number of sources to imagetools, but not that
+          # they covered distinct platforms. Read the published manifest
+          # back and assert linux/amd64 + linux/arm64 are both present.
+          # buildx attaches provenance/SBOM as extra `unknown/unknown` entries
+          # in the manifest list — skip those, we only care about real images.
+          got=$(
+            docker buildx imagetools inspect --raw "$IMAGE" \
+              | jq -r '
+                .manifests[]
+                | select(.platform.os != "unknown")
+                | "\(.platform.os)/\(.platform.architecture)"
+              ' \
+              | sort -u
+          )
+          expected=$(printf 'linux/amd64\nlinux/arm64')
+          if [[ "$got" != "$expected" ]]; then
+            echo "::error::manifest platforms mismatch — expected: $expected; got: $got"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Publish `ghcr.io/.../jammin-as-lan` as a multi-arch manifest list covering `linux/amd64` and `linux/arm64`, instead of single-arch amd64.
- Build each platform natively on its own runner (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) rather than under QEMU — the Dockerfile cargo-compiles `wasm-pvm-cli` with LLVM-18, which is prohibitively slow under emulation.
- Smoke tests (`wasm-pvm --help`, `node --version`) now run on real arm64 hardware, catching any arch-specific dynamic-linker or glibc issues that the previous amd64-only run would have missed.

## Workflow shape

Restructured `.github/workflows/docker-jammin.yml` from 2 jobs (`build`, `push`) into 3:

- **`tags`** — computes image name + tag list once (incl. the release version-consistency check). Both downstream jobs consume its outputs, so the logic isn't duplicated.
- **`build`** — matrix over `{linux/amd64 on ubuntu-latest, linux/arm64 on ubuntu-24.04-arm}`. Each runner loads its native build locally for the smoke test and, on non-PR triggers, additionally pushes by digest and uploads the digest as an artifact. Cache scopes are per-platform so the two arches don't stomp on each other.
- **`merge`** — non-PR only. Downloads both digest artifacts and uses `docker buildx imagetools create` to assemble a multi-arch manifest list under the final tag(s), then inspects it.

## Tradeoffs worth calling out

- PRs now run two full Rust/LLVM compiles in parallel — one per runner. The per-platform GHA cache should keep repeat runs cheap, but the first PR after this merges will be slow on both sides.
- `ubuntu-24.04-arm` is free for public repos. If the repo ever flips to private, arm64 runner minutes will bill at a higher rate than amd64.
- No changes to `docker/jammin-as-lan.Dockerfile` — it was already arch-agnostic.

## Test plan

- [ ] CI build matrix runs and both platforms pass on this PR (smoke test included).
- [ ] After merge to `main`, the scheduled push path produces a multi-arch manifest at `ghcr.io/<owner>/jammin-as-lan:main-<sha>` — verify with `docker buildx imagetools inspect`.
- [ ] Next release tag pushes both `:<version>` and `:latest` as multi-arch manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)