### PR TITLE
ci: unblock release publish + keep lockfiles in sync

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -40,17 +40,39 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: "npm"
+
       - name: Bump versions
         run: |
           npm version "$VERSION" --no-git-tag-version --allow-same-version=false
           (cd sdk && npm version "$VERSION" --no-git-tag-version --allow-same-version=false)
           (cd sdk-ecalli-mocks && npm version "$VERSION" --no-git-tag-version --allow-same-version=false)
 
+      - name: Regenerate lockfiles
+        # Each example depends on sdk and sdk-ecalli-mocks via `file:` and
+        # embeds their versions in its own package-lock.json, so every
+        # example's lockfile has to be refreshed alongside the three
+        # published manifests.
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          (cd sdk && npm install --package-lock-only --ignore-scripts)
+          (cd sdk-ecalli-mocks && npm install --package-lock-only --ignore-scripts)
+          for d in examples/*/; do
+            (cd "$d" && npm install --package-lock-only --ignore-scripts)
+          done
+
       - name: Create release branch and commit
         run: |
           BRANCH="release/v$VERSION"
           git checkout -b "$BRANCH"
-          git add package.json sdk/package.json sdk-ecalli-mocks/package.json
+          git add \
+            package.json sdk/package.json sdk-ecalli-mocks/package.json \
+            package-lock.json sdk/package-lock.json sdk-ecalli-mocks/package-lock.json \
+            examples/*/package-lock.json
           git commit -m "chore(release): v$VERSION"
           git push -u origin "$BRANCH"
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,7 +32,10 @@ jobs:
           cache: "npm"
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        # Pinned: `npm@latest` sometimes ships self-upgrade regressions
+        # (e.g. 11.13.0 crashed with MODULE_NOT_FOUND on `promise-retry`).
+        # Bump manually after confirming a newer version upgrades cleanly.
+        run: npm install -g npm@11.12.1
 
       - name: Install LLVM 18
         run: sudo apt-get update -qq && sudo apt-get install -y -qq llvm-18-dev libpolly-18-dev

--- a/examples/all-ecalli/package-lock.json
+++ b/examples/all-ecalli/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/examples/authorizer/package-lock.json
+++ b/examples/authorizer/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/examples/ecalli-test/package-lock.json
+++ b/examples/ecalli-test/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/examples/fibonacci/package-lock.json
+++ b/examples/fibonacci/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/examples/library/package-lock.json
+++ b/examples/library/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/examples/nested-pvm-spi/package-lock.json
+++ b/examples/nested-pvm-spi/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/examples/pastebin/package-lock.json
+++ b/examples/pastebin/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../sdk": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "../../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluffylabs/as-lan-workspace",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluffylabs/as-lan-workspace",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MPL-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/sdk-ecalli-mocks/package-lock.json
+++ b/sdk-ecalli-mocks/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluffylabs/as-lan-ecalli-mocks",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MPL-2.0",
       "devDependencies": {
         "typescript": "^6.0.0"

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluffylabs/as-lan",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluffylabs/as-lan",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MPL-2.0",
       "devDependencies": {
         "assemblyscript": "^0.28.10",
@@ -15,7 +15,7 @@
     },
     "../sdk-ecalli-mocks": {
       "name": "@fluffylabs/as-lan-ecalli-mocks",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Pin `npm@11.12.1` in `release-publish.yml`. The v0.0.2 run failed on `npm install -g npm@latest` because npm 11.13.0 (released 2026-04-22, two days before our publish attempt) crashed mid-self-upgrade with `MODULE_NOT_FOUND: promise-retry`. Pinning avoids future self-upgrade regressions; bump manually after verifying a newer version upgrades cleanly.
- Regenerate lockfiles during `release-prepare.yml`. The workflow bumped each `package.json` via `npm version` but only staged manifests — so every release shipped with stale `package-lock.json` files (v0.0.2's root/sdk/sdk-ecalli-mocks lockfiles still said `0.0.1`, and the root lockfile's `name` was still the pre-rename `@fluffylabs/as-lan`). Each example also embeds the sdk and sdk-ecalli-mocks versions via `file:`, so their lockfiles drift too.
- Add a `Setup Node.js` step and run `npm install --package-lock-only --ignore-scripts` in root, `sdk/`, `sdk-ecalli-mocks/`, and each `examples/*/` (10 lockfiles total). All refreshed lockfiles are staged alongside the manifests in the release commit.
- Include a one-shot regeneration of the currently-stale lockfiles so merging this PR brings `main` into sync with the already-tagged v0.0.2.

## Test plan
- [ ] Locally confirmed `npm install --package-lock-only --ignore-scripts` in all 10 dirs produces zero further changes against the regenerated lockfiles on this branch.
- [ ] Pre-push QA (`biome ci`) passes.
- [ ] Next `Release: Prepare` dispatch produces a commit that touches manifests **and** all 10 lockfiles.
- [ ] Next `Release: Publish` run gets past the npm upgrade step on npm 11.12.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)