### PR TITLE
ci: fix jammin smoke-test reusable workflow permissions

### DIFF
--- a/.github/workflows/_jammin-platform.yml
+++ b/.github/workflows/_jammin-platform.yml
@@ -35,12 +35,13 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
-    permissions:
-      # Upper bound — the calling workflow's job permissions further constrain
-      # this. Smoke-test calls forward only `contents: read`; publish calls
-      # additionally forward `packages: write`.
-      contents: read
-      packages: write
+    # Permissions are inherited from the calling job. GitHub Actions requires
+    # any `permissions` declared here to be a subset of the caller's grants,
+    # so we can't declare `packages: write` unconditionally — the smoke-test
+    # caller only grants `contents: read`, and the call would fail validation.
+    # Smoke-test callers grant only `contents: read` (push steps are gated on
+    # `inputs.push` and skipped). Publish callers additionally grant
+    # `packages: write` so the GHCR login + push-by-digest can run.
     steps:
       - name: Checkout (release tag)
         if: github.event_name == 'release'


### PR DESCRIPTION
## Summary

- The smoke-test call to `_jammin-platform.yml` was failing validation with `The nested job 'build' is requesting 'packages: write', but is only allowed 'packages: none'`.
- Cause: the reusable workflow declared `permissions: { contents: read, packages: write }` as an "upper bound", but GitHub Actions requires the called workflow's declared permissions to be a *subset* of the calling job's grants — and the smoke-test caller only grants `contents: read`.
- Fix: drop the `permissions` block from the reusable workflow's job. The called job now inherits the caller's permissions directly, which is the gating the design always wanted: smoke-test inherits `contents: read` (push steps are gated on `if: inputs.push` and skipped), publish inherits `contents: read` + `packages: write` for the GHCR login + push-by-digest.

## Test plan

- [ ] CI: PR run of `Build jammin-as-lan image` validates without the nested-permissions error and the smoke-test build matrix completes on `linux/amd64` and `linux/arm64`.
- [ ] After merge: a `main` push runs the full `build` -> `push` -> `merge` chain and produces a multi-arch `ghcr.io/.../jammin-as-lan:main-<sha>` manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)