### PR TITLE
ci: drop npm self-upgrade in release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,12 +31,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: "npm"
 
-      - name: Upgrade npm for trusted publishing
-        # Pinned: `npm@latest` sometimes ships self-upgrade regressions
-        # (e.g. 11.13.0 crashed with MODULE_NOT_FOUND on `promise-retry`).
-        # Bump manually after confirming a newer version upgrades cleanly.
-        run: npm install -g npm@11.12.1
-
       - name: Install LLVM 18
         run: sudo apt-get update -qq && sudo apt-get install -y -qq llvm-18-dev libpolly-18-dev
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,


### PR DESCRIPTION
## Summary
- Removes the `npm install -g npm@<version>` step in `release-publish.yml` — the thing that was breaking v0.0.2 and v0.0.3 publish runs with `MODULE_NOT_FOUND: promise-retry`.
- The step (added in #120) was based on the stale assumption that "Node 22 ships npm 10.x". Node 22.18.0 bumped the bundled npm to 11.x, and 22.22.x ships an npm well past 11.5.1 (the threshold for trusted publishing). `build.yml` runs `npm ci` against the same Node 22.x with no upgrade step and is consistently green, confirming the bundled npm is healthy.
- Both v0.0.2 (`npm@latest` → 11.13.0) and v0.0.3 (`npm@11.12.1`) crashed inside the *incoming* tarball's arborist `rebuild.js`, so the upgrade step was the failure rather than a workaround for it.

## Test plan
- [ ] Cut a v0.0.4 release-prepare PR after merge; confirm Release: Publish no longer fails at the upgrade step and publishes both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)