### PR TITLE
docker: pre-bake SDK deps so mounted services skip npm install

### DIFF
--- a/.github/workflows/_jammin-platform.yml
+++ b/.github/workflows/_jammin-platform.yml
@@ -80,6 +80,53 @@ jobs:
           # dynamic-linker errors (glibc version, missing shared libs, …).
           docker run --rm "${{ inputs.primary-tag }}" wasm-pvm --help
           docker run --rm "${{ inputs.primary-tag }}" node --version
+          # asc must be on PATH from the global assemblyscript install.
+          docker run --rm "${{ inputs.primary-tag }}" asc --version
+
+      - name: Smoke test — no-args run prints help and exits 64
+        run: |
+          set -eu
+          # Default CMD is a usage message that exits 64 (EX_USAGE). Guards
+          # against a future refactor that accidentally restores an
+          # `npm install`-bearing CMD; jammin always passes its own command,
+          # so this CMD should never run during normal use.
+          set +e
+          out=$(docker run --rm "${{ inputs.primary-tag }}")
+          rc=$?
+          set -e
+          echo "$out"
+          if [ "$rc" -ne 64 ]; then
+            echo "::error::expected exit 64 from no-args run, got $rc"
+            exit 1
+          fi
+          echo "$out" | grep -q 'jammin-as-lan: builder image'
+
+      - name: Smoke test — pre-baked SDK resolves without npm install
+        run: |
+          set -eux
+          # A service mounted at /app with no node_modules must still
+          # compile via `asc` because the entrypoint symlinks the global
+          # node_modules into /app/node_modules.
+          stub=$(mktemp -d)
+          mkdir -p "$stub/assembly"
+          cat > "$stub/package.json" <<'EOF'
+          {
+            "name": "smoke-stub",
+            "version": "0.0.0",
+            "type": "module",
+            "scripts": {
+              "asbuild": "asc assembly/index.ts --target debug --runtime=stub"
+            }
+          }
+          EOF
+          cat > "$stub/assembly/index.ts" <<'EOF'
+          import { Bytes32 } from "@fluffylabs/as-lan/core/bytes";
+          export function ping(): u32 {
+            return Bytes32.zero().length;
+          }
+          EOF
+          docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
+            npm run asbuild
 
       - name: Report uncompressed image size
         run: |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,39 @@ npm run qa-fix
 
 The build produces both `.wasm` and `.pvm` (PolkaVM/JAM SPI binary) files in the `build/` directory of each service. The `.pvm` file is what gets deployed to JAM.
 
+## Docker image (`jammin-as-lan`)
+
+A pre-baked builder image is published to GHCR for use with [jammin]
+(https://github.com/fluffylabs/jammin) or any environment that needs a
+ready-to-run AssemblyScript + PVM toolchain:
+
+```bash
+docker pull ghcr.io/fluffylabs/jammin-as-lan:latest
+```
+
+The image ships with `wasm-pvm`, Node.js, and the following packages
+pre-installed globally — **no `npm install` required** for a service whose
+only `devDependencies` are these three:
+
+- `@fluffylabs/as-lan`
+- `@fluffylabs/as-lan-ecalli-mocks`
+- `assemblyscript`
+
+Mount your service source at `/app` and pass the build/test command:
+
+```bash
+docker run --rm -v "$(pwd):/app" ghcr.io/fluffylabs/jammin-as-lan:latest \
+    npm run build
+```
+
+If your `node_modules/` directory is absent at startup, the image's
+entrypoint symlinks the global install into `/app/node_modules` so `asc`
+can resolve `@fluffylabs/as-lan`. If you bring your own `node_modules`
+(e.g., installed on the host), it wins — the symlink is skipped.
+
+A service that depends on additional npm packages still has to install
+those itself.
+
 ## Releases
 
 Published packages on npm:

--- a/docker/jammin-as-lan.Dockerfile
+++ b/docker/jammin-as-lan.Dockerfile
@@ -53,8 +53,43 @@ RUN set -eux; \
 
 COPY --from=builder /usr/local/cargo/bin/wasm-pvm /usr/local/bin/wasm-pvm
 
+# Pre-bake SDK + mocks + assemblyscript so a mounted service can build
+# without running `npm install`. The layout under /opt/as-lan/ mirrors the
+# repo so the SDK's prepack hook (`cp ../pvm-adapter.wat .`) resolves.
+COPY pvm-adapter.wat        /opt/as-lan/pvm-adapter.wat
+COPY sdk-ecalli-mocks       /opt/as-lan/sdk-ecalli-mocks
+COPY sdk                    /opt/as-lan/sdk
+
+# Build the mocks (TypeScript -> dist/) so the published-shape package
+# resolves "main": "dist/index.js" once globally installed.
+RUN cd /opt/as-lan/sdk-ecalli-mocks \
+    && npm ci --omit=optional \
+    && npm run build
+
+# Read assemblyscript version from sdk/package.json so the image's asc
+# matches what the SDK is tested against. --omit=dev keeps SDK devDeps
+# (like the file:../sdk-ecalli-mocks alias) out of the global install.
+RUN ASC_VERSION=$(node -p \
+        "require('/opt/as-lan/sdk/package.json').devDependencies.assemblyscript") \
+    && npm install -g --omit=dev \
+        /opt/as-lan/sdk \
+        /opt/as-lan/sdk-ecalli-mocks \
+        "assemblyscript@$ASC_VERSION"
+
+# Make globally-installed packages discoverable to Node code (test runners,
+# build scripts) without a local node_modules.
+ENV NODE_PATH=/usr/local/lib/node_modules
+
 WORKDIR /app
 
-# jammin passes the command to `docker run` directly, so no ENTRYPOINT.
-# The default CMD is a convenience for `docker run <image>` without args.
-CMD ["sh", "-c", "npm install && npm run build"]
+# AssemblyScript's compiler (`asc`) resolves `import "@fluffylabs/as-lan"` by
+# walking up looking for a `node_modules/` directory — it does NOT honor
+# NODE_PATH. So at container start we symlink the global install location
+# to /app/node_modules unless the mount already supplied one. The symlink
+# only lives in the container's writable layer; --rm cleans it up.
+ENTRYPOINT ["/bin/sh", "-c", "[ -e /app/node_modules ] || ln -s /usr/local/lib/node_modules /app/node_modules; exec \"$@\"", "--"]
+
+# jammin passes the command to `docker run` directly, so no behavior change
+# for it. The default CMD prints usage and exits 64 (EX_USAGE) when the
+# image is run with no arguments, so a misuse doesn't masquerade as success.
+CMD ["sh", "-c", "cat <<'EOF'\njammin-as-lan: builder image for @fluffylabs/as-lan AssemblyScript services.\n\nMount your service source at /app and pass a build/test command, e.g.:\n  docker run --rm -v \"$(pwd):/app\" jammin-as-lan npm run build\n\nPre-installed (no `npm install` required for these):\n  - @fluffylabs/as-lan\n  - @fluffylabs/as-lan-ecalli-mocks\n  - assemblyscript (asc on PATH)\n\nAlso on PATH:\n  - wasm-pvm\n\nA service whose package.json declares only the three pre-installed packages\nas devDependencies does NOT need to run npm install inside the container.\nEOF\nexit 64"]


### PR DESCRIPTION
## Summary

- Bake `@fluffylabs/as-lan`, `@fluffylabs/as-lan-ecalli-mocks`, and `assemblyscript` (version pinned by `sdk/package.json`) into the `jammin-as-lan` image as global installs, so a mounted service no longer has to `npm install` them on every run.
- An `ENTRYPOINT` symlinks `/usr/local/lib/node_modules` into `/app/node_modules` when the mount didn't supply one — `asc` walks `node_modules/` for `@fluffylabs/as-lan` resolution and ignores `NODE_PATH`, so the global install alone isn't enough.
- Default `CMD` becomes a usage help message that exits 64 (`EX_USAGE`); `jammin` always passes its own command, so this only fires on misuse.
- Three new CI smoke tests: `asc --version`, no-args help + exit 64, and a stub service mounted at `/app` that compiles via `asc` with no `npm install`.
- README gets a "Docker image (`jammin-as-lan`)" section documenting the mount/usage contract.

The `NODE_PATH`-only approach was tried first and rejected because `asc` doesn't honor it; the symlink fallback was verified locally with the fibonacci example (asbuild succeeds with no host `node_modules`).

## Test plan

- [x] Local `docker buildx build` for `linux/arm64` succeeds
- [x] `docker run --rm jammin-as-lan` prints help and exits 64
- [x] `docker run --rm jammin-as-lan wasm-pvm --help` / `node --version` / `asc --version` all succeed
- [x] Mounted stub service compiles via `asc` with no `node_modules` (entrypoint creates the symlink)
- [x] Mounted service that brings its own `node_modules` is left untouched
- [ ] CI passes on `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)