### PR TITLE
ci: bump Node to 24.x for npm 11 + trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 env:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 24.x
 
 jobs:
   build-and-test:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: "npm"
 
       - name: Bump versions

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 24.x
 
 jobs:
   publish:

--- a/.github/workflows/sizes.yml
+++ b/.github/workflows/sizes.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 env:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 24.x
 
 permissions:
   pull-requests: write

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,

--- a/docker/jammin-as-lan.Dockerfile
+++ b/docker/jammin-as-lan.Dockerfile
@@ -2,13 +2,13 @@
 #
 # Builder image for the @fluffylabs/as-lan SDK, compatible with jammin.
 # Two-stage: stage 1 compiles wasm-pvm-cli from crates.io, stage 2 is a
-# minimal node:22-slim runtime carrying only the resulting binary.
+# minimal node:24-bookworm-slim runtime carrying only the resulting binary.
 
 # ---- Stage 1: build wasm-pvm ---------------------------------------------
 # Pinned to bookworm so the resulting binary's glibc requirements match the
-# runtime stage (node:22-slim, also bookworm). Unpinned `rust:1-slim` tracks
-# the current stable, which may drift to a newer Debian with a higher glibc
-# and produce binaries that fail at runtime with `GLIBC_X.Y not found`.
+# runtime stage (node:24-bookworm-slim). Unpinned `rust:1-slim` tracks the
+# current stable, which may drift to a newer Debian with a higher glibc and
+# produce binaries that fail at runtime with `GLIBC_X.Y not found`.
 FROM rust:1-slim-bookworm AS builder
 
 # wasm-pvm-cli needs llvm-18 headers + libpolly at compile time. Neither
@@ -41,7 +41,7 @@ RUN set -eux; \
 RUN cargo install wasm-pvm-cli@0.8.0 --locked
 
 # ---- Stage 2: runtime ----------------------------------------------------
-FROM node:22-slim AS runtime
+FROM node:24-bookworm-slim AS runtime
 
 # ca-certificates: npm registry TLS. git: npm deps pointing at git URLs.
 RUN set -eux; \


### PR DESCRIPTION
## Summary

- Node 22 LTS ships npm 10.x throughout its line, so removing the self-upgrade in #132 left `release-publish` on an npm version trusted publishing rejects (https://github.com/tomusdrw/as-lan/actions/runs/25519387047/job/74899085593#step:13:83).
- Bump `NODE_VERSION` `22.x` → `24.x` across `build.yml`, `sizes.yml`, `release-prepare.yml`, `release-publish.yml`. Node 24 is the current Active LTS (since Oct 2025) and ships npm 11.x by default, so trusted publishing works without any `npm install -g npm@…` workaround.
- Move `docker/jammin-as-lan` runtime from `node:22-slim` → `node:24-bookworm-slim`. Explicit `bookworm` pin preserves the glibc invariant with the `rust:1-slim-bookworm` builder stage (default `node:24-slim` may track a newer Debian).

## Test plan

- [ ] Build CI run on this PR is green on Node 24.
- [ ] Sizes report posts on this PR (sanity check the Node 24 setup-node step works).
- [ ] Cut a patch release after merge; verify `Release: Publish` shows npm 11.x and the trusted-publish step succeeds end-to-end.
- [ ] Pull `node:24-bookworm-slim` and rebuild the Docker image to confirm the tag exists and `wasm-pvm` runs (no `GLIBC_X.Y not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)