### PR TITLE
docker: pack SDK before global install so prepack ships pvm-adapter.wat

### DIFF
--- a/.github/workflows/_jammin-platform.yml
+++ b/.github/workflows/_jammin-platform.yml
@@ -159,6 +159,41 @@ jobs:
             exit 1
           fi
 
+      - name: Smoke test — entrypoint adopts orphan managed symlink
+        run: |
+          set -eux
+          # Recovery path for SIGKILLed prior runs. SIGKILL bypasses our
+          # EXIT/INT/TERM traps, so the managed symlink leaks onto the
+          # host. The entrypoint should treat any /app/node_modules link
+          # whose target matches our managed path as ours and clean it
+          # up on the next successful run.
+          stub=$(mktemp -d)
+          ln -s /usr/local/lib/node_modules "$stub/node_modules"
+          docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
+            true
+          if [ -L "$stub/node_modules" ] || [ -e "$stub/node_modules" ]; then
+            echo "::error::orphan managed symlink not reclaimed by entrypoint"
+            ls -la "$stub"
+            exit 1
+          fi
+
+      - name: Smoke test — entrypoint leaves user-supplied node_modules alone
+        run: |
+          set -eux
+          # If the user mounts a real node_modules at /app, the entrypoint
+          # must not delete it on exit. Same for a user-created symlink
+          # pointing somewhere we don't manage.
+          stub=$(mktemp -d)
+          mkdir "$stub/node_modules"
+          touch "$stub/node_modules/MARKER"
+          docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
+            true
+          if [ ! -f "$stub/node_modules/MARKER" ]; then
+            echo "::error::entrypoint clobbered user-supplied node_modules"
+            ls -la "$stub"
+            exit 1
+          fi
+
       - name: Report uncompressed image size
         run: |
           docker image inspect "${{ inputs.primary-tag }}" \

--- a/.github/workflows/_jammin-platform.yml
+++ b/.github/workflows/_jammin-platform.yml
@@ -128,6 +128,37 @@ jobs:
           docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
             npm run asbuild
 
+      - name: Smoke test — pvm-adapter.wat reachable from /app/node_modules
+        run: |
+          set -eux
+          # jammin's default `pvm` script invokes wasm-pvm with
+          # `--adapter node_modules/@fluffylabs/as-lan/pvm-adapter.wat`,
+          # a relative path resolved from the service cwd (/app). This
+          # regresses if the SDK is installed via a path that bypasses the
+          # `prepack` hook (e.g. `npm install -g <localdir>` without
+          # packing first), because pvm-adapter.wat is staged into the
+          # package by prepack.
+          stub=$(mktemp -d)
+          docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
+            test -f node_modules/@fluffylabs/as-lan/pvm-adapter.wat
+
+      - name: Smoke test — entrypoint cleans up /app/node_modules symlink
+        run: |
+          set -eux
+          # /app is bind-mounted, so any symlink the entrypoint creates
+          # there leaks onto the host. Verify the entrypoint removes it
+          # on exit, otherwise users see a dangling
+          # services/<svc>/node_modules -> /usr/local/lib/node_modules
+          # link that breaks subsequent host-side `npm install`.
+          stub=$(mktemp -d)
+          docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
+            true
+          if [ -L "$stub/node_modules" ] || [ -e "$stub/node_modules" ]; then
+            echo "::error::entrypoint left node_modules behind in bind-mounted /app"
+            ls -la "$stub"
+            exit 1
+          fi
+
       - name: Report uncompressed image size
         run: |
           docker image inspect "${{ inputs.primary-tag }}" \

--- a/.github/workflows/_jammin-platform.yml
+++ b/.github/workflows/_jammin-platform.yml
@@ -182,14 +182,31 @@ jobs:
           set -eux
           # If the user mounts a real node_modules at /app, the entrypoint
           # must not delete it on exit. Same for a user-created symlink
-          # pointing somewhere we don't manage.
+          # pointing at a target we don't manage.
           stub=$(mktemp -d)
+
+          # Subcase 1: real directory.
           mkdir "$stub/node_modules"
           touch "$stub/node_modules/MARKER"
           docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
             true
           if [ ! -f "$stub/node_modules/MARKER" ]; then
-            echo "::error::entrypoint clobbered user-supplied node_modules"
+            echo "::error::entrypoint clobbered user-supplied node_modules dir"
+            ls -la "$stub"
+            exit 1
+          fi
+          rm -rf "$stub/node_modules"
+
+          # Subcase 2: user-created symlink to a non-managed target. The
+          # entrypoint must not adopt or remove it (target string differs
+          # from /usr/local/lib/node_modules).
+          mkdir "$stub/user-target"
+          touch "$stub/user-target/MARKER"
+          ln -s "$stub/user-target" "$stub/node_modules"
+          docker run --rm -v "$stub:/app" "${{ inputs.primary-tag }}" \
+            true
+          if [ ! -L "$stub/node_modules" ] || [ ! -f "$stub/node_modules/MARKER" ]; then
+            echo "::error::entrypoint clobbered user-supplied node_modules symlink"
             ls -la "$stub"
             exit 1
           fi

--- a/docker/jammin-as-lan-entrypoint.sh
+++ b/docker/jammin-as-lan-entrypoint.sh
@@ -20,7 +20,13 @@ MANAGED_LINK_TARGET=/usr/local/lib/node_modules
 CREATED_LINK=
 
 cleanup() {
-    if [ -n "$CREATED_LINK" ] && [ -L /app/node_modules ]; then
+    # Re-check the target on exit too: the command may have repointed the
+    # link mid-run (unlikely for asc/wasm-pvm, but cheap to guard against).
+    # Only remove a symlink that still matches what we'd have created, so
+    # ownership doesn't silently transfer if the user took over.
+    if [ -n "$CREATED_LINK" ] \
+            && [ -L /app/node_modules ] \
+            && [ "$(readlink /app/node_modules)" = "$MANAGED_LINK_TARGET" ]; then
         rm -f /app/node_modules
     fi
 }

--- a/docker/jammin-as-lan-entrypoint.sh
+++ b/docker/jammin-as-lan-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Bridge the global node_modules into /app for asc/wasm-pvm relative-path
+# lookups. AssemblyScript's compiler walks up from the entry file looking
+# for `node_modules/` (it does NOT honor NODE_PATH), and jammin's default
+# `pvm` script invokes wasm-pvm with `--adapter
+# node_modules/@fluffylabs/as-lan/pvm-adapter.wat` — both need
+# /app/node_modules to resolve.
+#
+# Caveat: /app is bind-mounted from the host, so the symlink we create
+# there leaks onto the host filesystem. `docker run --rm` only cleans up
+# the container's writable layer; bind-mounted paths are user-managed.
+# Track ownership and remove the symlink in an EXIT trap so a successful
+# run leaves the host directory untouched. SIGINT/SIGTERM are also
+# trapped (docker stop hits us with SIGTERM after a 10s grace period).
+# SIGKILL is uncatchable — abruptly killed containers may still leak.
+
+CREATED_LINK=
+
+cleanup() {
+    if [ -n "$CREATED_LINK" ] && [ -L /app/node_modules ]; then
+        rm -f /app/node_modules
+    fi
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+if [ ! -e /app/node_modules ]; then
+    ln -s /usr/local/lib/node_modules /app/node_modules
+    CREATED_LINK=1
+fi
+
+"$@"

--- a/docker/jammin-as-lan-entrypoint.sh
+++ b/docker/jammin-as-lan-entrypoint.sh
@@ -12,8 +12,11 @@
 # Track ownership and remove the symlink in an EXIT trap so a successful
 # run leaves the host directory untouched. SIGINT/SIGTERM are also
 # trapped (docker stop hits us with SIGTERM after a 10s grace period).
-# SIGKILL is uncatchable — abruptly killed containers may still leak.
+# SIGKILL is uncatchable — abruptly killed containers may still leak,
+# so we also adopt any pre-existing symlink that points at our managed
+# target on entry, letting a later successful run clean up the leak.
 
+MANAGED_LINK_TARGET=/usr/local/lib/node_modules
 CREATED_LINK=
 
 cleanup() {
@@ -25,8 +28,15 @@ trap cleanup EXIT
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
-if [ ! -e /app/node_modules ]; then
-    ln -s /usr/local/lib/node_modules /app/node_modules
+# Adopt a leftover from a SIGKILLed prior run if it points at the same
+# target we'd create — readlink returns the literal string we wrote, so
+# an exact match means it's ours. Anything else (user-supplied dir,
+# user-created symlink to somewhere else) is left alone.
+if [ -L /app/node_modules ] \
+        && [ "$(readlink /app/node_modules)" = "$MANAGED_LINK_TARGET" ]; then
+    CREATED_LINK=1
+elif [ ! -e /app/node_modules ] && [ ! -L /app/node_modules ]; then
+    ln -s "$MANAGED_LINK_TARGET" /app/node_modules
     CREATED_LINK=1
 fi
 

--- a/docker/jammin-as-lan.Dockerfile
+++ b/docker/jammin-as-lan.Dockerfile
@@ -69,10 +69,20 @@ RUN cd /opt/as-lan/sdk-ecalli-mocks \
 # Read assemblyscript version from sdk/package.json so the image's asc
 # matches what the SDK is tested against. --omit=dev keeps SDK devDeps
 # (like the file:../sdk-ecalli-mocks alias) out of the global install.
-RUN ASC_VERSION=$(node -p \
-        "require('/opt/as-lan/sdk/package.json').devDependencies.assemblyscript") \
-    && npm install -g --omit=dev \
-        /opt/as-lan/sdk \
+#
+# `npm install -g <localdir>` symlinks the source folder and skips the
+# `prepack` lifecycle, so files staged into the package by prepack (here:
+# pvm-adapter.wat, copied from the repo root) never reach the global
+# install. Pack the SDK first so the install matches the published
+# tarball — prepack runs, the .wat lands inside the package, and
+# `--adapter node_modules/@fluffylabs/as-lan/pvm-adapter.wat` from a
+# downstream service resolves.
+RUN set -eux; \
+    cd /opt/as-lan/sdk && npm pack; \
+    ASC_VERSION=$(node -p \
+        "require('/opt/as-lan/sdk/package.json').devDependencies.assemblyscript"); \
+    npm install -g --omit=dev \
+        /opt/as-lan/sdk/fluffylabs-as-lan-*.tgz \
         /opt/as-lan/sdk-ecalli-mocks \
         "assemblyscript@$ASC_VERSION"
 
@@ -84,10 +94,13 @@ WORKDIR /app
 
 # AssemblyScript's compiler (`asc`) resolves `import "@fluffylabs/as-lan"` by
 # walking up looking for a `node_modules/` directory — it does NOT honor
-# NODE_PATH. So at container start we symlink the global install location
-# to /app/node_modules unless the mount already supplied one. The symlink
-# only lives in the container's writable layer; --rm cleans it up.
-ENTRYPOINT ["/bin/sh", "-c", "[ -e /app/node_modules ] || ln -s /usr/local/lib/node_modules /app/node_modules; exec \"$@\"", "--"]
+# NODE_PATH. The entrypoint symlinks the global install to /app/node_modules
+# unless the mount already supplied one, then removes the symlink on exit so
+# the bind-mounted host directory isn't left with a dangling pointer into
+# the container's filesystem.
+COPY docker/jammin-as-lan-entrypoint.sh /usr/local/bin/jammin-as-lan-entrypoint
+RUN chmod +x /usr/local/bin/jammin-as-lan-entrypoint
+ENTRYPOINT ["/usr/local/bin/jammin-as-lan-entrypoint"]
 
 # jammin passes the command to `docker run` directly, so no behavior change
 # for it. The default CMD prints usage and exits 64 (EX_USAGE) when the


### PR DESCRIPTION
## Summary

Fixes `jammin build` against `ghcr.io/tomusdrw/jammin-as-lan:0.0.4`, which fails with:

```
> wasm-pvm compile build/release.wasm -o example.jam --adapter node_modules/@fluffylabs/as-lan/pvm-adapter.wat
Error: Failed to read adapter node_modules/@fluffylabs/as-lan/pvm-adapter.wat
Caused by: No such file or directory (os error 2)
```

### Root cause

`npm install -g <localdir>` symlinks the source folder and bypasses the `prepack` lifecycle, so the SDK's `cp ../pvm-adapter.wat .` hook never runs and the global install lacks the adapter file. The published npm tarball is fine — `npm publish` runs prepack — only the pre-baked SDK in the `jammin-as-lan` Docker image was broken.

The user-reported file listing of the installed package (`tsconfig.json` and `package-lock.json` present despite not being in the `files` array) was the giveaway: those leak through symlink/copy mode but would be filtered out by `npm pack`.

### Fix

- **Pack-then-install** in `jammin-as-lan.Dockerfile`: `cd sdk && npm pack` first, then `npm install -g /opt/as-lan/sdk/fluffylabs-as-lan-*.tgz`. Prepack runs, the `.wat` lands inside the package, and `--adapter node_modules/@fluffylabs/as-lan/pvm-adapter.wat` resolves from a downstream service. The install now matches the published tarball shape.

- **Entrypoint cleanup** (`docker/jammin-as-lan-entrypoint.sh`, new): The previous inline `ENTRYPOINT` created `/app/node_modules` but never removed it. Since `/app` is bind-mounted, `--rm` left a dangling `services/<svc>/node_modules -> /usr/local/lib/node_modules` symlink on the host that broke subsequent host-side `npm install`. New script tracks ownership in `CREATED_LINK` and removes the symlink on `EXIT`/`INT`/`TERM`. SIGKILL is uncatchable — abruptly killed containers may still leak (documented).

- **Two new CI smoke tests** in `_jammin-platform.yml` to lock in both fixes:
  - `test -f node_modules/@fluffylabs/as-lan/pvm-adapter.wat` from inside `/app` — catches missing-adapter regressions.
  - After `docker run --rm … true`, assert the bind-mounted `$stub/node_modules` is gone — catches host-leak regressions.

## Test plan

- [x] Verified locally: `npm pack` followed by `npm install --omit=dev` from absolute tarball path produces `pvm-adapter.wat` in the install and respects the `files` array.
- [x] Verified locally: entrypoint script creates the symlink only when `/app/node_modules` is absent, removes it on exit, preserves exit codes (tested with 0, 7, 42), and leaves user-supplied `node_modules` alone.
- [x] `npm run qa` / `npm run build` / `npm test` pass via the pre-push hook.
- [ ] CI rebuild of the image with the new smoke tests passes on amd64 + arm64.

## Follow-ups (separate)

- Bump version via "Release: Prepare" → publish → triggers Docker image rebuild as `0.0.5`.
- Add `aslan-0.0.5` to jammin's recognized SDK list (separate repo: `FluffyLabs/jammin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)