### PR TITLE
docker: symlink ecalli -> as-lan-ecalli-mocks so jammin test resolves it

### DIFF
--- a/docker/jammin-as-lan.Dockerfile
+++ b/docker/jammin-as-lan.Dockerfile
@@ -86,6 +86,18 @@ RUN set -eux; \
         /opt/as-lan/sdk-ecalli-mocks \
         "assemblyscript@$ASC_VERSION"
 
+# AssemblyScript's ESM bindings emit `import * as __import0 from "ecalli"` —
+# literally the WASM import namespace from `@external("ecalli", …)`. No
+# `ecalli` package exists on npm; templates work around it with a
+# `"ecalli": "npm:@fluffylabs/as-lan-ecalli-mocks"` alias resolved by
+# `npm install`. This image deliberately skips `npm install` in mounted
+# services, so the alias never materializes — symlink the mocks under the
+# expected name. TODO: long-term, rename the import namespace to a scoped
+# name (e.g. "@fluffylabs/as-lan-ecalli") so consumers don't depend on a
+# generic top-level module.
+RUN ln -s /usr/local/lib/node_modules/@fluffylabs/as-lan-ecalli-mocks \
+          /usr/local/lib/node_modules/ecalli
+
 # Make globally-installed packages discoverable to Node code (test runners,
 # build scripts) without a local node_modules.
 ENV NODE_PATH=/usr/local/lib/node_modules


### PR DESCRIPTION
## Summary

- AssemblyScript's `bindings: esm` emits `import * as __import0 from \"ecalli\"` — literally the WASM import namespace from `@external(\"ecalli\", ...)`. No top-level `ecalli` package exists on npm.
- Templates work around this with a `\"ecalli\": \"npm:@fluffylabs/as-lan-ecalli-mocks\"` alias resolved by `npm install`. The native SDK image deliberately skips `npm install` in mounted services, so the alias never materializes and `jammin test` fails with `ERR_MODULE_NOT_FOUND` for `ecalli`.
- Fix: add a global symlink `/usr/local/lib/node_modules/ecalli -> @fluffylabs/as-lan-ecalli-mocks` in the SDK image so the literal import resolves against the pre-installed mocks.

## Why this approach

The alternatives — running `npm install` in the image's build/test steps, or renaming the WASM import namespace to a scoped name like `@fluffylabs/as-lan-ecalli` — were considered:

- `npm install` per-build slows every invocation and re-introduces the symlink-leak class of bugs the entrypoint already works hard to avoid.
- Renaming the namespace is cleaner but a breaking change across the SDK, mocks, and every existing template. A `TODO` is left in the Dockerfile comment to track this as a long-term follow-up.

The global symlink is contained to the image's writable layer (no bind-mount leak risk) and costs nothing at runtime.

## Follow-ups not in this PR

- No version bump — release flow handles that. Once this lands and an `aslan-0.0.6` release is cut, jammin's SDK registry needs the new id.
- Long-term: rename the WASM import namespace to a scoped name so consumers don't depend on a generic top-level module.

## Test plan

- [ ] `docker build -f docker/jammin-as-lan.Dockerfile -t jammin-as-lan:test .` succeeds.
- [ ] `docker run --rm jammin-as-lan:test ls -l /usr/local/lib/node_modules/ecalli` shows the symlink.
- [ ] `docker run --rm jammin-as-lan:test node -e 'import(\"ecalli\").then(m => console.log(Object.keys(m).length))'` prints a non-zero count.
- [ ] End-to-end: fresh aslan template → `jammin build` produces `dist/example.jam` (no regression) → `jammin test` runs the AssemblyScript test suite to completion (no `ERR_MODULE_NOT_FOUND`).
- [ ] No `node_modules` symlink leaks into the service directory after either command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)