### PR TITLE
perf: shrink PVM output ~11% via codec rewrite + -Os build

### DIFF
--- a/examples/all-ecalli/asconfig.json
+++ b/examples/all-ecalli/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/examples/authorizer/asconfig.json
+++ b/examples/authorizer/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/examples/ecalli-test/asconfig.json
+++ b/examples/ecalli-test/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/examples/fibonacci/asconfig.json
+++ b/examples/fibonacci/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/examples/library/asconfig.json
+++ b/examples/library/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/examples/nested-pvm-spi/asconfig.json
+++ b/examples/nested-pvm-spi/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/examples/pastebin/asconfig.json
+++ b/examples/pastebin/asconfig.json
@@ -12,7 +12,7 @@
       "textFile": "build/release.wat",
       "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 2,
+      "shrinkLevel": 1,
       "converge": true,
       "noAssert": true
     },

--- a/sdk/core/bytes.ts
+++ b/sdk/core/bytes.ts
@@ -158,12 +158,16 @@ export class Bytes32 {
   }
 }
 
-const CODE_OF_0: i32 = "0".charCodeAt(0);
-const CODE_OF_9: i32 = "9".charCodeAt(0);
-const CODE_OF_a: i32 = "a".charCodeAt(0);
-const CODE_OF_f: i32 = "f".charCodeAt(0);
-const CODE_OF_A: i32 = "A".charCodeAt(0);
-const CODE_OF_F: i32 = "F".charCodeAt(0);
+// ASCII codes for '0', '9', 'a', 'f', 'A', 'F'. Inlined here rather than
+// derived from `"0".charCodeAt(0)` etc. — AS evaluates `charCodeAt` at
+// module-init (`~start`), which re-runs on every PVM invocation and
+// emits dead `String#charCodeAt` calls into every service.
+const CODE_OF_0: i32 = 0x30;
+const CODE_OF_9: i32 = 0x39;
+const CODE_OF_a: i32 = 0x61;
+const CODE_OF_f: i32 = 0x66;
+const CODE_OF_A: i32 = 0x41;
+const CODE_OF_F: i32 = 0x46;
 const VALUE_OF_A: i32 = 0xa;
 
 function byteFromString(s: string): U8WithError {

--- a/sdk/core/codec/decode.ts
+++ b/sdk/core/codec/decode.ts
@@ -37,20 +37,27 @@ export class Decoder {
     return new Decoder(source.raw);
   }
 
-  private readonly dataView: DataView;
+  // Cached pointer + length of `source`. With `--runtime=stub` the bump
+  // allocator never moves objects, so `dataStart` is stable for the life
+  // of the decoder. Direct `load<T>` writes avoid the DataView allocation
+  // and per-read bounds-checked accessor calls.
+  private readonly ptr: usize;
+  private readonly srcLen: u32;
   private _isError: boolean = false;
 
   private constructor(
     public readonly source: Uint8Array,
     private offset: u32 = 0,
   ) {
-    this.dataView = new DataView(source.buffer, source.byteOffset, source.byteLength);
+    this.ptr = source.dataStart;
+    this.srcLen = <u32>source.length;
   }
 
   /**
    * If the decoder turns into error state, the last value was not decoded properly
    * and might be garbage.
    */
+  @inline
   get isError(): boolean {
     return this._isError;
   }
@@ -68,6 +75,7 @@ export class Decoder {
    * Return the number of bytes read from the source
    * (i.e. current offset within the source).
    */
+  @inline
   bytesRead(): u32 {
     return this.offset;
   }
@@ -76,7 +84,7 @@ export class Decoder {
   u8(): u8 {
     const offset = this.moveOffset(1);
     if (offset !== -1) {
-      return this.dataView.getUint8(offset);
+      return load<u8>(this.ptr + offset);
     }
     return 0;
   }
@@ -85,7 +93,7 @@ export class Decoder {
   u16(): u16 {
     const offset = this.moveOffset(2);
     if (offset !== -1) {
-      return this.dataView.getUint16(offset, true);
+      return load<u16>(this.ptr + offset);
     }
     return 0;
   }
@@ -94,9 +102,9 @@ export class Decoder {
   u24(): u32 {
     const offset = this.moveOffset(3);
     if (offset !== -1) {
-      const lo = this.dataView.getUint16(offset, true);
-      const hi = this.dataView.getUint8(offset + 2);
-      return u32(lo) | (u32(hi) << 16);
+      const lo = <u32>load<u16>(this.ptr + offset);
+      const hi = <u32>load<u8>(this.ptr + offset + 2);
+      return lo | (hi << 16);
     }
     return 0;
   }
@@ -105,7 +113,7 @@ export class Decoder {
   u32(): u32 {
     const offset = this.moveOffset(4);
     if (offset !== -1) {
-      return this.dataView.getUint32(offset, true);
+      return load<u32>(this.ptr + offset);
     }
     return 0;
   }
@@ -114,7 +122,7 @@ export class Decoder {
   u64(): u64 {
     const offset = this.moveOffset(8);
     if (offset !== -1) {
-      return this.dataView.getUint64(offset, true);
+      return load<u64>(this.ptr + offset);
     }
     return 0;
   }
@@ -141,7 +149,7 @@ export class Decoder {
       return 0;
     }
 
-    const firstByte = this.source[offset];
+    const firstByte = load<u8>(this.ptr + offset);
     const l = decodeVariableLengthExtraBytes(firstByte);
 
     if (l === 0) {
@@ -154,12 +162,12 @@ export class Decoder {
     }
 
     if (l === 8) {
-      return this.dataView.getUint64(offset, true);
+      return load<u64>(this.ptr + offset);
     }
 
     let num = (u64(firstByte) + 2 ** (8 - l) - 2 ** 8) << (8 * l);
-    for (let i = 0; i < <i32>l; i += 1) {
-      num |= u64(this.source[offset + i]) << (8 * i);
+    for (let i: u32 = 0; i < <u32>l; i += 1) {
+      num |= u64(load<u8>(this.ptr + offset + i)) << (8 * i);
     }
     return num;
   }
@@ -282,7 +290,7 @@ export class Decoder {
    */
   isFinished(): boolean {
     // TODO [ToDr] set isError?
-    return this.offset === this.source.length;
+    return this.offset === this.srcLen;
   }
 
   // Progress the offset, but return the previous offset or -1 if not enough bytes.
@@ -296,8 +304,9 @@ export class Decoder {
     return -1;
   }
 
+  @inline
   private hasBytes(bytes: u32): boolean {
-    return bytes <= <u32>this.source.length - this.offset;
+    return bytes <= this.srcLen - this.offset;
   }
 }
 

--- a/sdk/core/codec/encode.ts
+++ b/sdk/core/codec/encode.ts
@@ -39,7 +39,11 @@ export class Encoder {
     return new Encoder(buffer, false);
   }
 
-  private dataView: DataView;
+  // Cached pointer + capacity of `data`. Refreshed on every grow. Direct
+  // `store<T>` writes here avoid the `DataView` object allocation and the
+  // per-write bounds-checked accessor calls.
+  private ptr: usize;
+  private cap: u32;
   private offset: u32 = 0;
   private _isError: boolean = false;
 
@@ -47,22 +51,25 @@ export class Encoder {
     private data: Uint8Array,
     private readonly growable: boolean,
   ) {
-    this.dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    this.ptr = data.dataStart;
+    this.cap = <u32>data.length;
   }
 
   /** Whether writing has overflowed the buffer (fixed-size mode only). */
+  @inline
   get isError(): boolean {
     return this._isError;
   }
 
   /** Return the number of bytes written so far. */
+  @inline
   bytesWritten(): u32 {
     return this.offset;
   }
 
   /** Return the encoded bytes, trimmed to the actual length. */
   finishRaw(): Uint8Array {
-    if (this.data.length === this.offset) {
+    if (<u32>this.data.length === this.offset) {
       return this.data;
     }
     return this.data.subarray(0, this.offset);
@@ -76,36 +83,36 @@ export class Encoder {
   /** Encode a single byte. */
   u8(value: u8): void {
     if (!this.ensureCapacity(1)) return;
-    this.dataView.setUint8(this.offset, value);
+    store<u8>(this.ptr + this.offset, value);
     this.offset += 1;
   }
 
   /** Encode two bytes (little-endian). */
   u16(value: u16): void {
     if (!this.ensureCapacity(2)) return;
-    this.dataView.setUint16(this.offset, value, true);
+    store<u16>(this.ptr + this.offset, value);
     this.offset += 2;
   }
 
   /** Encode three bytes (little-endian). */
   u24(value: u32): void {
     if (!this.ensureCapacity(3)) return;
-    this.dataView.setUint16(this.offset, u16(value & 0xffff), true);
-    this.dataView.setUint8(this.offset + 2, u8((value >> 16) & 0xff));
+    store<u16>(this.ptr + this.offset, u16(value & 0xffff));
+    store<u8>(this.ptr + this.offset + 2, u8((value >> 16) & 0xff));
     this.offset += 3;
   }
 
   /** Encode 4 bytes (little-endian). */
   u32(value: u32): void {
     if (!this.ensureCapacity(4)) return;
-    this.dataView.setUint32(this.offset, value, true);
+    store<u32>(this.ptr + this.offset, value);
     this.offset += 4;
   }
 
   /** Encode 8 bytes (little-endian). */
   u64(value: u64): void {
     if (!this.ensureCapacity(8)) return;
-    this.dataView.setUint64(this.offset, value, true);
+    store<u64>(this.ptr + this.offset, value);
     this.offset += 8;
   }
 
@@ -124,9 +131,9 @@ export class Encoder {
 
     if (l === 8) {
       if (!this.ensureCapacity(9)) return;
-      this.dataView.setUint8(this.offset, 0xff);
+      store<u8>(this.ptr + this.offset, 0xff);
       this.offset += 1;
-      this.dataView.setUint64(this.offset, value, true);
+      store<u64>(this.ptr + this.offset, value);
       this.offset += 8;
       return;
     }
@@ -135,12 +142,12 @@ export class Encoder {
     // First byte: prefix mask | high bits of value
     const shifted = value >> (8 * l);
     const prefix = u8(2 ** 8 - 2 ** (8 - l));
-    this.dataView.setUint8(this.offset, prefix | u8(shifted));
+    store<u8>(this.ptr + this.offset, prefix | u8(shifted));
     this.offset += 1;
 
     // Remaining l bytes: low bits, little-endian
     for (let i: u8 = 0; i < l; i += 1) {
-      this.dataView.setUint8(this.offset, u8(value >> (8 * i)));
+      store<u8>(this.ptr + this.offset, u8(value >> (8 * i)));
       this.offset += 1;
     }
   }
@@ -152,12 +159,12 @@ export class Encoder {
 
   /** Encode a fixed-length sequence of bytes. */
   bytesFixLen(value: BytesBlob): void {
-    const len = value.length;
+    const len = <u32>value.length;
     if (len === 0) {
       return;
     }
     if (!this.ensureCapacity(len)) return;
-    this.data.set(value.raw, this.offset);
+    memory.copy(this.ptr + this.offset, value.raw.dataStart, len);
     this.offset += len;
   }
 
@@ -199,23 +206,27 @@ export class Encoder {
    * Ensure the internal buffer has room for `bytes` more bytes.
    * Returns true if space is available, false if the buffer is full (fixed-size mode).
    */
+  @inline
   private ensureCapacity(bytes: u32): boolean {
     if (this._isError) {
       return false;
     }
 
-    const remaining = <u32>this.data.length - this.offset;
-    if (bytes <= remaining) {
+    if (bytes <= this.cap - this.offset) {
       return true;
     }
 
+    return this.grow(bytes);
+  }
+
+  private grow(bytes: u32): boolean {
     if (!this.growable) {
       this._isError = true;
       return false;
     }
 
     const required = this.offset + bytes;
-    let newCapacity = <u32>this.data.length;
+    let newCapacity = this.cap;
     if (newCapacity === 0) {
       newCapacity = DEFAULT_CAPACITY;
     }
@@ -224,9 +235,10 @@ export class Encoder {
     }
 
     const newData = new Uint8Array(newCapacity);
-    newData.set(this.data.subarray(0, this.offset));
+    memory.copy(newData.dataStart, this.ptr, this.offset);
     this.data = newData;
-    this.dataView = new DataView(newData.buffer, 0, newCapacity);
+    this.ptr = newData.dataStart;
+    this.cap = newCapacity;
     return true;
   }
 }


### PR DESCRIPTION
## Summary

Closes some of the WASM→PVM compilation gap. Three internal-only changes (no public API churn) that together drop PVM ops ~11% and PVM blob size ~10% across all 7 example services.

| Service | WASM Δ | PVM ops Δ | PVM blob Δ |
|---|---|---|---|
| fibonacci      |  -8.3% | **-13.1%** (4084 → 3548) | **-11.8%** (19.5K → 17.2K) |
| all-ecalli     |  -3.1% |   -6.9% (9390 → 8738)    |   -6.0% (46.7K → 43.9K)   |
| authorizer     |  -9.0% |  -11.3% (2685 → 2380)    |  -10.9% (13.7K → 12.2K)   |
| ecalli-test    |  -1.2% |   -8.2% (11000 → 10100)  |   -6.8% (56.2K → 52.4K)   |
| pastebin       |  -3.5% | **-14.0%** (9456 → 8132) | **-12.8%** (43.0K → 37.5K)|
| library        |  -1.3% |  -11.8% (11900 → 10500)  |   -9.9% (57.7K → 52.0K)   |
| nested-pvm-spi |  -3.7% |  -11.1% (7291 → 6479)    |   -9.0% (37.6K → 34.2K)   |

## What changed

- **`Encoder`/`Decoder`**: drop `DataView` in favor of cached `ptr`/`cap` (Encoder) and `ptr`/`srcLen` (Decoder) with direct `store<T>`/`load<T>`. Removes one allocation per codec instance plus the per-access bounds-checked DataView wrapper calls. `ensureCapacity` split into inline hot-path + out-of-line `grow`.
- **`core/bytes.ts`**: replace `"0".charCodeAt(0)` style const-init with literal `0x30` etc. AS evaluates these constants in `~start`, which re-runs every PVM invocation — so the dead `String#charCodeAt` calls were paid per request.
- **`examples/*/asconfig.json`**: `shrinkLevel: 2 → 1` (`-Oz → -Os`). This was the single biggest contributor. `-Oz` inhibits Binaryen's inliner, leaving trivial `ByteBuf#set:_ptr`/`set:_pos`/... setters as separate functions that become PVM call/return sequences. `-Os` inlines them. After this flip the final WAT contains **0 setter functions** and **0 `DataView` references** (was 9 setters + many DataView wrappers in baseline).

## What didn't make the cut

- Per-method `@inline` on `Encoder.u8/u16/u32/u64`: tried, *increased* PVM ops ~2% because each callsite duplicates the `ensureCapacity` arithmetic. Reverted. `@inline` on `ensureCapacity` itself (with cold `grow` split out) is the right granularity.
- Raising `wasm-pvm --inline-threshold`: grows blobs by ~20% with no op-count win. The AS-side `shrinkLevel` is the knob that matters.

## Test plan

- [x] `npm run sdk:test` — 218 / 218 ✅
- [x] All 7 example test suites — 110 / 110 ✅
- [x] Before/after PVM stats captured via `wasm-pvm compile --verbose` on every example
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)